### PR TITLE
Finally fix DMux4Way and -8Way for a modest savings

### DIFF
--- a/project_01.py
+++ b/project_01.py
@@ -72,10 +72,12 @@ def mkDMux4Way(inputs, outputs):
     lo = DMux(in_=in_, sel=sel[0])
     sel1 = sel[1]
     not_sel1 = Not(in_=sel1).out
-    outputs.a = DMuxPlus(in_=lo.a, not_sel=not_sel1, sel=sel1).a
-    outputs.b = DMuxPlus(in_=lo.b, not_sel=not_sel1, sel=sel1).a
-    outputs.c = DMuxPlus(in_=lo.a, not_sel=not_sel1, sel=sel1).b
-    outputs.d = DMuxPlus(in_=lo.b, not_sel=not_sel1, sel=sel1).b
+    dmux1 = DMuxPlus(in_=lo.a, not_sel=not_sel1, sel=sel1)
+    dmux2 = DMuxPlus(in_=lo.b, not_sel=not_sel1, sel=sel1)
+    outputs.a = dmux1.a
+    outputs.b = dmux2.a
+    outputs.c = dmux1.b
+    outputs.d = dmux2.b
     
 DMux4Way = build(mkDMux4Way)
 
@@ -97,14 +99,18 @@ def mkDMux8Way(inputs, outputs):
     lo = DMux(in_=in_, sel=sel[0])
     lo0 = DMuxPlus(in_=lo.a, not_sel=not_sel1, sel=sel1)
     lo1 = DMuxPlus(in_=lo.b, not_sel=not_sel1, sel=sel1)
-    outputs.a = DMuxPlus(in_=lo0.a, not_sel=not_sel2, sel=sel2).a
-    outputs.b = DMuxPlus(in_=lo1.a, not_sel=not_sel2, sel=sel2).a
-    outputs.c = DMuxPlus(in_=lo0.b, not_sel=not_sel2, sel=sel2).a
-    outputs.d = DMuxPlus(in_=lo1.b, not_sel=not_sel2, sel=sel2).a
-    outputs.e = DMuxPlus(in_=lo0.a, not_sel=not_sel2, sel=sel2).b
-    outputs.f = DMuxPlus(in_=lo1.a, not_sel=not_sel2, sel=sel2).b
-    outputs.g = DMuxPlus(in_=lo0.b, not_sel=not_sel2, sel=sel2).b
-    outputs.h = DMuxPlus(in_=lo1.b, not_sel=not_sel2, sel=sel2).b
+    dmux1 = DMuxPlus(in_=lo0.a, not_sel=not_sel2, sel=sel2)
+    dmux2 = DMuxPlus(in_=lo1.a, not_sel=not_sel2, sel=sel2)
+    dmux3 = DMuxPlus(in_=lo0.b, not_sel=not_sel2, sel=sel2)
+    dmux4 = DMuxPlus(in_=lo1.b, not_sel=not_sel2, sel=sel2)
+    outputs.a = dmux1.a
+    outputs.b = dmux2.a
+    outputs.c = dmux3.a
+    outputs.d = dmux4.a
+    outputs.e = dmux1.b
+    outputs.f = dmux2.b
+    outputs.g = dmux3.b
+    outputs.h = dmux4.b
     
 DMux8Way = build(mkDMux8Way)
 

--- a/test_05.py
+++ b/test_05.py
@@ -412,7 +412,7 @@ def cycles_per_second():
 
 def test_speed():
     cps = cycles_per_second()
-    print(f"Measured speed: {cps} cycles/s")
+    print(f"Measured speed: {cps:0.1f} cycles/s")
     assert cps > 100
  
 

--- a/test_optimal_01.py
+++ b/test_optimal_01.py
@@ -26,10 +26,10 @@ def test_dmux():
     assert gate_count(DMux)['nands'] == 5
 
 def test_dmux4way():
-    assert gate_count(DMux4Way)['nands'] == 22  # optimal?
+    assert gate_count(DMux4Way)['nands'] == 14  # optimal?
 
 def test_dmux8way():
-    assert gate_count(DMux8Way)['nands'] == 47  # optimal?
+    assert gate_count(DMux8Way)['nands'] == 31  # optimal?
 
 def test_not16():
     assert gate_count(Not16)['nands'] == 16

--- a/test_optimal_03.py
+++ b/test_optimal_03.py
@@ -28,13 +28,13 @@ def test_register():
 
 def test_ram8():
     assert gate_count(RAM8) == {
-        'nands': 898,  # ?
+        'nands': 882,  # ?
         'dffs': 128
     }
 
 def test_ram64():
     assert gate_count(RAM64) == {
-        'nands': 7_570,  # ?
+        'nands': 7_426,  # ?
         'dffs': 1_024
     }
 

--- a/test_optimal_05.py
+++ b/test_optimal_05.py
@@ -6,7 +6,7 @@ from project_05 import *
 
 def test_memory_system():
     assert gate_count(MemorySystem) == {
-        'nands': 171,  # ?
+        'nands': 163,  # ?
         'rams': 2,
         'inputs': 1,
     }
@@ -19,7 +19,7 @@ def test_cpu():
 
 def test_computer():
     assert gate_count(Computer) == {
-        'nands': 1270,  # ?
+        'nands': 1262,  # ?
         'dffs': 48,  # 3 registers
         'roms': 1,
         'rams': 2,


### PR DESCRIPTION
This mostly affects the DFF-based RAMs, which aren't used in the CPU anyway, but it also was provoking a benign but annoying bug in IC flattening.