### PR TITLE
Miscellaneous improvements

### DIFF
--- a/computer.py
+++ b/computer.py
@@ -24,7 +24,7 @@ import project_06
 
 
 EVENT_INTERVAL = 1/10
-DISPLAY_INTERVAL = 1/10  # Note: screen update is pretty slow at this point, so no point in trying for a higher frame rate.
+DISPLAY_INTERVAL = 1/5  # Note: screen update is pretty slow at this point, so no point in trying for a higher frame rate.
 CYCLE_INTERVAL = 1.0
 
 COLORS = [0xFFFFFF, 0x000000]
@@ -130,13 +130,13 @@ def main():
 
         if now >= last_cycle_time + CYCLE_INTERVAL:
             cps = (cycles - last_cycle_count)/(now - last_cycle_time)
-            pygame.display.set_caption(f"{sys.argv[1]}: {cycles//1000:0,d}k cycles; {cps/1000:0,.1f}k/s")
+            pygame.display.set_caption(f"{sys.argv[1]}: {cycles//1000:0,d}k cycles; {cps/1000:0,.1f}k/s; PC: {computer.pc}")
             last_cycle_time = now
             last_cycle_count = cycles
             
             # print(f"cycles: {cycles//1000:0,d}k; pc: {computer.pc}")
-            # # print(f"mem@00:   {', '.join(hex(computer.peek(i))[2:].rjust(4, '0') for i in range(16))}")
-            # # print(f"mem@16:   {', '.join(hex(computer.peek(i+16))[2:].rjust(4, '0') for i in range(16))}")
+            # print(f"mem@00:   {', '.join(hex(computer.peek(i))[2:].rjust(4, '0') for i in range(16))}")
+            # print(f"mem@16:   {', '.join(hex(computer.peek(i+16))[2:].rjust(4, '0') for i in range(16))}")
 
 
 if __name__ == "__main__":

--- a/computer.py
+++ b/computer.py
@@ -24,7 +24,7 @@ import project_06
 
 
 EVENT_INTERVAL = 1/10
-DISPLAY_INTERVAL = 1/5  # Note: screen update is pretty slow at this point, so no point in trying for a higher frame rate.
+DISPLAY_INTERVAL = 1/10  # Note: screen update is pretty slow at this point, so no point in trying for a higher frame rate.
 CYCLE_INTERVAL = 1.0
 
 COLORS = [0xFFFFFF, 0x000000]
@@ -116,27 +116,29 @@ def main():
     while True:
         computer.ticktock(); cycles += 1
 
-        now = time.monotonic()
+        # Note: check the time only every few frames to reduce the overhead of timing
+        if cycles % 10 == 0:
+            now = time.monotonic()
         
-        # A few times per second, process events and update the display:
-        if now >= last_event_time + EVENT_INTERVAL:
-            last_event_time = now
-            key = kvm.process_events()
-            computer.set_keydown(key or 0)
+            # A few times per second, process events and update the display:
+            if now >= last_event_time + EVENT_INTERVAL:
+                last_event_time = now
+                key = kvm.process_events()
+                computer.set_keydown(key or 0)
 
-        if now >= last_display_time + DISPLAY_INTERVAL:
-            last_display_time = now
-            kvm.update_display(computer.peek_screen)
+            if now >= last_display_time + DISPLAY_INTERVAL:
+                last_display_time = now
+                kvm.update_display(computer.peek_screen)
 
-        if now >= last_cycle_time + CYCLE_INTERVAL:
-            cps = (cycles - last_cycle_count)/(now - last_cycle_time)
-            pygame.display.set_caption(f"{sys.argv[1]}: {cycles//1000:0,d}k cycles; {cps/1000:0,.1f}k/s; PC: {computer.pc}")
-            last_cycle_time = now
-            last_cycle_count = cycles
+            if now >= last_cycle_time + CYCLE_INTERVAL:
+                cps = (cycles - last_cycle_count)/(now - last_cycle_time)
+                pygame.display.set_caption(f"{sys.argv[1]}: {cycles//1000:0,d}k cycles; {cps/1000:0,.1f}k/s; PC: {computer.pc}")
+                last_cycle_time = now
+                last_cycle_count = cycles
             
-            # print(f"cycles: {cycles//1000:0,d}k; pc: {computer.pc}")
-            # print(f"mem@00:   {', '.join(hex(computer.peek(i))[2:].rjust(4, '0') for i in range(16))}")
-            # print(f"mem@16:   {', '.join(hex(computer.peek(i+16))[2:].rjust(4, '0') for i in range(16))}")
+                # print(f"cycles: {cycles//1000:0,d}k; pc: {computer.pc}")
+                # print(f"mem@00:   {', '.join(hex(computer.peek(i))[2:].rjust(4, '0') for i in range(16))}")
+                # print(f"mem@16:   {', '.join(hex(computer.peek(i+16))[2:].rjust(4, '0') for i in range(16))}")
 
 
 if __name__ == "__main__":

--- a/examples/FastDraw.asm
+++ b/examples/FastDraw.asm
@@ -1,0 +1,85 @@
+// Fill the entire screen with junk as quickly as possible. About 10k cycles.
+
+  @SCREEN
+  D=A
+  @ptr
+  M=D  
+
+  // initialize the loop var:
+  @256
+  D=A
+  @count
+  M=D
+
+(loop)
+  @_1
+  D=A
+  @return
+  M=D
+  
+  @copy
+  0;JMP
+  
+(_1)
+  @count
+  DM=M-1
+  @loop
+  D;JGT
+
+(halt)
+  @halt
+  0;JMP
+  
+
+
+(copy)
+  // Write nonsense to an entire scanline of pixels, as fast as possible (1 instructions per 16 pixels,
+  // about 8k instructions for the whole screen):
+  // @ptr: the address to start copying to
+  // @return: address to jump to after
+  // on return, @ptr points to the next line
+  
+  @ptr
+  A=M
+  
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  AM=A+1
+  
+  // update @ptr
+  D=A
+  @ptr
+  M=D
+  
+  @return
+  A=M
+  0;JMP

--- a/examples/FillScreen.asm
+++ b/examples/FillScreen.asm
@@ -1,0 +1,130 @@
+// Fill the entire screen with a 50% gray pattern, as quickly as possible, or nearly. About 20k cycles.
+
+  @SCREEN
+  D=A
+  @ptr
+  M=D  
+
+  @0x5555
+  D=A
+  @pixels
+  M=D
+
+  // initialize the loop var:
+  @256
+  D=A
+  @count
+  M=D
+
+(loop)
+  // Flip pixels from previous line:
+  @pixels
+  M=!M
+  
+  @_1
+  D=A
+  @return
+  M=D
+  
+  @copy
+  0;JMP
+  
+(_1)
+  @count
+  DM=M-1
+  @loop
+  D;JGT
+
+(halt)
+  @halt
+  0;JMP
+  
+
+
+(copy)
+  // Copy one word to one entire scanline of pixels, as fast as possible (2 instructions per 16 pixels,
+  // about 16k instructions for the whole screen):
+  // @pixels: 16 pixels
+  // @ptr: the address to start copying to
+  // @return: address to jump to after
+  // on return, @ptr points to the next line
+  
+  @pixels
+  D=M
+  
+  @ptr
+  A=M
+  
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  M=D
+  A=A+1
+  
+  // update @ptr
+  D=A
+  @ptr
+  M=D
+  
+  @return
+  A=M
+  0;JMP

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -29,7 +29,7 @@ the memory layout also entails constructing a new UI harness, which is beside th
 """
 
 from nand.component import Nand, Const, ROM
-from nand.integration import IC, Connection, root
+from nand.integration import IC, Connection, root, clock
 from nand.optimize import simplify
 from nand.vector import extend_sign
 
@@ -75,6 +75,9 @@ def generate_python(ic):
     # print(ic)
     
     all_comps = ic.sorted_components()
+
+    if any(conn == clock for conn in ic.wires.values()):
+        raise NotImplementedError("This simulator cannot handle chips that refer to 'clock' directly.")
 
     supr = 'SOC' if any(isinstance(c, IC) and c.label == 'MemorySystem' for c in all_comps) else 'Chip'
 

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -97,12 +97,12 @@ def generate_python(ic):
         else:
             value = f"_{all_comps.index(conn.comp)}_{conn.name}"
 
-        if conn.bit != 0:
-            return f"({value} & (1 << {conn.bit}) != 0)"
+        if conn.bit != 0 or any(c.comp == conn.comp and c.name == conn.name and c.bit != 0 for c in ic.wires.values()):
+            return f"({value} & {hex(1 << conn.bit)} != 0)"
         elif conn.comp.label == "Register":
             raise Exception("TODO: unexpected wiring for 1-bit component")
         else:
-            return f"({value} & 0b1 != 0)" 
+            return value
 
     def src_many(comp, name, bits=None):
         if bits is None:

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -81,7 +81,6 @@ def generate_python(ic):
     lines = []
     def l(indent, str):
         l = "    "*indent + str
-        # print(f"> {l}")
         lines.append(l)
 
     def src_one(comp, name):

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -114,6 +114,8 @@ def generate_python(ic):
         for i in range(1, bits):
             conn_i = ic.wires[Connection(comp, name, i)]
             if conn_i.comp != conn0.comp or conn_i.name != conn0.name or conn_i.bit != i:
+                # TODO: handle assembly of multiple bits into one; (_123 << 15) | (_456 << 14) | ...
+                print(f"{conn0}; {conn_i} -> {Connection(comp, name, i)}")
                 raise Exception(f"TODO: unexpected wiring for {bits}-bit component")
         
         conn = conn0

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -233,7 +233,7 @@ def generate_python(ic):
         if bits == 1:
             l(2, f"self._{name} = {src_one(root, name)}")
         else:
-            l(2, f"self._{name} = {src_many(root, name)}")
+            l(2, f"self._{name} = {src_many(root, name, bits)}")
 
     l(2, "if update_state:")
     l(3,   "pass")

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -113,21 +113,18 @@ def generate_python(ic):
 
         conn0 = ic.wires[Connection(comp, name, 0)]
         src_conns = [(i, ic.wires.get(Connection(comp, name, i))) for i in range(bits)]
-        if all((c.comp == conn0.comp and c.name == conn0.name and c.bit == bit) for (bit, c) in src_conns):            
+        if all((c.comp == conn0.comp and c.name == conn0.name and c.bit == bit) for (bit, c) in src_conns):
             conn = conn0
         
             if isinstance(conn.comp, Const):
                 return conn.comp.value
 
             if conn.comp == root:
-                name = f"self._{conn.name}"
+                return f"self._{conn.name}"
+            elif conn.comp.label == "Register":
+                return f"self._{all_comps.index(conn.comp)}_{conn.name}"
             else:
-                name = f"_{all_comps.index(conn.comp)}_{conn.name}"
-
-            if conn.comp.label == "Register":
-                return f"self.{name}"
-            else:
-                return name    
+                return f"_{all_comps.index(conn.comp)}_{conn.name}"  # but it's always "out"?
         else:
             return "extend_sign(" + " | ".join(f"({src_one(comp, name, i)} << {i})" for i in range(bits)) + ")"
 

--- a/nand/integration.py
+++ b/nand/integration.py
@@ -25,12 +25,6 @@ class IC:
     def outputs(self):
         return self._outputs
 
-    def has_combine_ops(self):
-        """Just return True, because that's virtually always the case and the answer only becomes
-        interesting after flattening, when no child ICs are left anyway.
-        """
-        return True
-
     def wire(self, from_output, to_input):
         """Connect a single trace from an output of one component to an input of another.
 
@@ -246,7 +240,7 @@ class IC:
                 return ""
             elif isinstance(from_comp, Const):
                 return ""
-            elif not from_comp.has_combine_ops():
+            elif isinstance(from_comp, DFF):
                 return " (latched)"
             elif all_comps.index(from_comp) > all_comps.index(to_comp):
                 return " (back-edge)"

--- a/nand/vector.py
+++ b/nand/vector.py
@@ -153,28 +153,6 @@ class VectorOps:
         """
         return []
 
-    # def has_combine_ops(self):
-    #     """True if the component _ever_ updates any output in combinational fashion (as most do).
-    #     False only for components which only ever latch inputs and update their outputs during
-    #     flop/sequence.
-    #
-    #     This is useful for determining evaluation order: non-combinational components can be evaluated
-    #     later, which can help to break cycles (the same cycles that these components tend to
-    #     participate in.)
-    #
-    #     Current theory is that this only really needs to work for DFFs. Note that RAM, despite
-    #     having both combinational and sequential behavior, actually treats its one output as
-    #     combinational. However, if someone decides to implement a 16-bit Register with a purely
-    #     latched output, this will handle that.
-    #     """
-    #
-    #     trace_map = {
-    #         name: [0]*bits
-    #         for (name, bits) in itertools.chain(self.inputs().items(), self.outputs().items())
-    #     }
-    #     return len(self.combine(**trace_map)) > 0
-
-
 class NandOps(VectorOps):
     def combine(self, a, b, out):
         assert len(a) == 1 and len(b) == 1 and len(out) == 1

--- a/project_06.py
+++ b/project_06.py
@@ -58,9 +58,9 @@ def parse_op(string):
     to a symbol or variable.
     """
     
-    m = re.match(r"@(\d+)", string)
+    m = re.match(r"@((?:0x)?\d+)", string)
     if m:
-        return int(m.group(1))
+        return eval(m.group(1))
     else:
         m = re.match(r"(?:([ADM]+)=)?([^;]+)(?:;J(..))?", string)
         if m:


### PR DESCRIPTION
- inline results that are used only once (allowing some evaluation to be short-circuited)
- a couple more examples of screen drawing that show something faster than Pong's 5m cycles
- assembler: handle hex values in @- instructions
- reduce runtime overhead in codegen by also generating accessors for inputs and outputs