### PR TITLE
Bury the solved exercises under nand.solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # From Nand to Tetris in Python
 
 An alternative language and test harness for doing the exercises from the amazing book/course
-[Nand To Tetris](https://www.nand2tetris.org). My goal is to provide a better experience
-as compared to the tools provided by the authors:
+[Nand To Tetris](https://www.nand2tetris.org). This version, in Python, may provide a better 
+experience as compared to the tools provided by the authors:
 
 * No need to install Java
 * No clunky UI
-* You only need python, a text editor, and basic command-line skills.
+* You only need Python, a text editor, and basic command-line skills.
 
 
 ## Requirements
@@ -22,19 +22,20 @@ For the full Computer simulation including display and keyboard, `pygame` is req
 
 ## Step 1: Do the Exercises
 
-_NOTE: for the time being, solved versions of each component are included. When everything's 
-working as intended, we'll come back and clean it up so the exercises are ready to solve._
+First clone the repo and run `pytest`. All the tests should pass, because the included solutions 
+are used for every component.
 
-First clone the repo and run `pytest`. If your environment is set up, you should see a lot of 
-failing tests, because none of the components are implemented yet (except `Nand`, which you get 
-for free).
-
-Now open `project01.py` in a text editor, find the `mkNot` function, and replace the `___`s
-with references to the inputs so that it computes the expected result.
+Now open [project_01.py](project_01.py) in a text editor, find the `mkNot` function, and the line
+with `solved_01.Not`. Replace that with `Nand(a=..., b=...)` using the inputs so that it computes 
+the expected result.
 
 Run `pytest test_01.py`. If `test_not` passes, you can move on to the next component.
 
-When all those tests pass, you're done with the first chapter. Move on to test_02.py…
+When you're all done, delete the line `from nand.solutions import solved_01` at the top of the 
+file to be sure you didn't miss anything. Actually, if you prefer you can start by deleting that 
+line, then work on getting the tests to pass one at a time.
+
+That's it for the first chapter. Now move on to `test_02.py`…
 
 
 ## Step 2: Enjoy

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # From Nand to Tetris in Python
 
 An alternative language and test harness for doing the exercises from the amazing book/course
-[Nand To Tetris](https://www.nand2tetris.org). This version, in Python, may provide a better 
+[Nand To Tetris](https://www.nand2tetris.org). This version, in Python, may provide a better
 experience as compared to the tools provided by the authors:
 
 * No need to install Java
@@ -16,23 +16,23 @@ You need to have Python installed, at least version 3.6.
 Pytest is required to run the tests: `pip3 install pytest`.
 
 For the full Computer simulation including display and keyboard, `pygame` is required:
-`pip3 install pygame`. On Mac OS X, you may need to install a dev version: 
+`pip3 install pygame`. On Mac OS X, you may need to install a dev version:
 `pip3 install pygame==2.0.0dev6`
 
 
 ## Step 1: Do the Exercises
 
-First clone the repo and run `pytest`. All the tests should pass, because the included solutions 
+First clone the repo and run `pytest`. All the tests should pass, because the included solutions
 are used for every component.
 
 Now open [project_01.py](project_01.py) in a text editor, find the `mkNot` function, and the line
-with `solved_01.Not`. Replace that with `Nand(a=..., b=...)` using the inputs so that it computes 
+with `solved_01.Not`. Replace that with `Nand(a=..., b=...)` using the inputs so that it computes
 the expected result.
 
 Run `pytest test_01.py`. If `test_not` passes, you can move on to the next component.
 
-When you're all done, delete the line `from nand.solutions import solved_01` at the top of the 
-file to be sure you didn't miss anything. Actually, if you prefer you can start by deleting that 
+When you're all done, delete the line `from nand.solutions import solved_01` at the top of the
+file to be sure you didn't miss anything. Actually, if you prefer you can _start_ by deleting that
 line, then work on getting the tests to pass one at a time.
 
 That's it for the first chapter. Now move on to `test_02.py`…
@@ -56,7 +56,7 @@ The components here can be used to implement any generally similar CPU design. I
 - Make an even smaller CPU. What can you take away and still get stuff done?
 
 Note: if you want to run any programs, you'll have to figure out how to get them into
-your new chip's instruction format. One way to do that is to implement a new VM-assembly 
+your new chip's instruction format. One way to do that is to implement a new VM-assembly
 translator, and find some VM programs to run on both chips for comparison.
 
 

--- a/computer.py
+++ b/computer.py
@@ -102,7 +102,7 @@ class KVM:
 
 
 def main():
-    with open(sys.argv[1]) as f:
+    with open(sys.argv[1], mode='r') as f:
         prg = project_06.load_file(f)
 
     computer = run(project_05.Computer, simulator=os.environ.get("PYNAND_SIMULATOR") or 'codegen')

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -198,6 +198,13 @@ def generate_python(ic, inline=True):
             return unary16(comp, "{} == 0")
         elif comp.label == 'Inc16':
             return unary16(comp, "extend_sign({} + 1)")
+        elif comp.label == 'DMux':
+            return None  # note: multiple outputs doesn't really inline
+        elif comp.label == 'DMux8Way':
+            return None  # note: multiple outputs doesn't really inline
+        elif comp.label == 'Mux8Way16':
+            # TODO: this one _could_ be inlined with a large nested if/else expr.
+            return None
         elif comp.label == "Register":
             return None
         elif isinstance(comp, DFF):

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -17,7 +17,7 @@ A few more are implemented so that this simulator can also be used (and tested) 
 chips:
 - DFF
 - DMux
-- TODO: DMux8Way
+- DMux8Way
 - Mux8Way16
 - TODO: RAM
 

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -117,11 +117,11 @@ def generate_python(ic, inline=True):
             expr = component_expr(conn.comp)
             if expr:
                 value = f"({expr})"
-            elif isinstance(conn.comp, DFF):
+            elif conn.comp.label in ("DFF", "Register"):
                 value = f"self._{all_comps.index(conn.comp)}_{conn.name}"
             else:
                 value = f"_{all_comps.index(conn.comp)}_{conn.name}"
-        elif isinstance(conn.comp, DFF):
+        elif conn.comp.label in ("DFF", "Register"):
             value = f"self._{all_comps.index(conn.comp)}_{conn.name}"
         else:
             value = f"_{all_comps.index(conn.comp)}_{conn.name}"

--- a/nand/integration.py
+++ b/nand/integration.py
@@ -202,7 +202,7 @@ class IC:
         all_comps = self.sorted_components()
         def by_component(conn):
             if conn.comp == root:
-                num = -1  # inputs first 
+                num = -1  # inputs first
             elif conn.comp in all_comps:
                 num = all_comps.index(conn.comp)
             else:

--- a/nand/solutions/solved_01.py
+++ b/nand/solutions/solved_01.py
@@ -1,0 +1,185 @@
+"""Solutions for project 01.
+
+SPOILER ALERT: this files contains complete and optimal solutions for all the exercises.
+If you want to solve them on your own, stop reading now!
+"""
+
+from nand import *
+
+
+def mkNot(inputs, outputs):
+    in_ = inputs.in_
+    n = Nand(a=in_, b=in_)
+    outputs.out = n.out
+
+Not = build(mkNot)
+
+
+def mkOr(inputs, outputs):
+    a = inputs.a
+    b = inputs.b
+    notA = Not(in_=a)
+    notB = Not(in_=b)
+    notNotBoth = Nand(a=notA.out, b=notB.out)
+    outputs.out = notNotBoth.out
+
+Or = build(mkOr)
+
+
+def mkAnd(inputs, outputs):
+    a = inputs.a
+    b = inputs.b
+    notAandB = Nand(a=a, b=b).out
+    outputs.out = Not(in_=notAandB).out
+
+And = build(mkAnd)
+
+
+def mkXor(inputs, outputs):
+    a = inputs.a
+    b = inputs.b
+    nand = Nand(a=a, b=b).out
+    nandANand = Nand(a=a, b=nand).out
+    nandBNand = Nand(a=nand, b=b).out
+    outputs.out = Nand(a=nandANand, b=nandBNand).out
+
+Xor = build(mkXor)
+
+
+def mkMux(inputs, outputs):
+    a = inputs.a
+    b = inputs.b
+    sel = inputs.sel
+    fromAneg = Nand(a=a, b=Not(in_=sel).out).out
+    fromBneg = Nand(a=b, b=sel).out
+    outputs.out = Nand(a=fromAneg, b=fromBneg).out
+
+Mux = build(mkMux)
+
+
+def mkDMux(inputs, outputs):
+    in_ = inputs.in_
+    sel = inputs.sel
+    outputs.a = And(a=in_, b=Not(in_=sel).out).out
+    outputs.b = And(a=in_, b=sel).out
+
+DMux = build(mkDMux)
+
+
+def mkDMux4Way(inputs, outputs):
+    def mkDMuxPlus(inputs, outputs):
+        outputs.a = And(a=inputs.in_, b=inputs.not_sel).out
+        outputs.b = And(a=inputs.in_, b=inputs.sel).out
+    DMuxPlus = build(mkDMuxPlus)
+
+    # TODO: optimal?
+    in_ = inputs.in_
+    sel = inputs.sel
+    lo = DMux(in_=in_, sel=sel[0])
+    sel1 = sel[1]
+    not_sel1 = Not(in_=sel1).out
+    dmux1 = DMuxPlus(in_=lo.a, not_sel=not_sel1, sel=sel1)
+    dmux2 = DMuxPlus(in_=lo.b, not_sel=not_sel1, sel=sel1)
+    outputs.a = dmux1.a
+    outputs.b = dmux2.a
+    outputs.c = dmux1.b
+    outputs.d = dmux2.b
+    
+DMux4Way = build(mkDMux4Way)
+
+
+def mkDMux8Way(inputs, outputs):
+    def mkDMuxPlus(inputs, outputs):
+        outputs.a = And(a=inputs.in_, b=inputs.not_sel).out
+        outputs.b = And(a=inputs.in_, b=inputs.sel).out
+    DMuxPlus = build(mkDMuxPlus)
+
+    # TODO: optimal?
+    # TODO: implement bit slice syntax and use DMux4Way?
+    in_ = inputs.in_
+    sel = inputs.sel
+    sel1 = sel[1]
+    not_sel1 = Not(in_=sel1).out
+    sel2 = sel[2]
+    not_sel2 = Not(in_=sel2).out
+    lo = DMux(in_=in_, sel=sel[0])
+    lo0 = DMuxPlus(in_=lo.a, not_sel=not_sel1, sel=sel1)
+    lo1 = DMuxPlus(in_=lo.b, not_sel=not_sel1, sel=sel1)
+    dmux1 = DMuxPlus(in_=lo0.a, not_sel=not_sel2, sel=sel2)
+    dmux2 = DMuxPlus(in_=lo1.a, not_sel=not_sel2, sel=sel2)
+    dmux3 = DMuxPlus(in_=lo0.b, not_sel=not_sel2, sel=sel2)
+    dmux4 = DMuxPlus(in_=lo1.b, not_sel=not_sel2, sel=sel2)
+    outputs.a = dmux1.a
+    outputs.b = dmux2.a
+    outputs.c = dmux3.a
+    outputs.d = dmux4.a
+    outputs.e = dmux1.b
+    outputs.f = dmux2.b
+    outputs.g = dmux3.b
+    outputs.h = dmux4.b
+    
+DMux8Way = build(mkDMux8Way)
+
+
+def mkNot16(inputs, outputs):
+    in_ = inputs.in_
+    for i in range(16):
+        outputs.out[i] = Not(in_=in_[i]).out
+
+Not16 = build(mkNot16)
+        
+
+def mkAnd16(inputs, outputs):
+    for i in range(16):
+        outputs.out[i] = And(a=inputs.a[i], b=inputs.b[i]).out
+
+And16 = build(mkAnd16)
+
+
+def mkMux16(inputs, outputs):
+    not_sel = Not(in_=inputs.sel).out
+    for i in range(16):
+        fromAneg = Nand(a=inputs.a[i], b=not_sel).out
+        fromBneg = Nand(a=inputs.b[i], b=inputs.sel).out
+        outputs.out[i] = Nand(a=fromAneg, b=fromBneg).out
+
+Mux16 = build(mkMux16)
+
+
+def mkMux4Way16(inputs, outputs):
+    # Share not_sel to save one gate:
+    def mkMux16Plus(inputs, outputs):
+        for i in range(16):
+            fromAneg = Nand(a=inputs.a[i], b=inputs.not_sel).out
+            fromBneg = Nand(a=inputs.b[i], b=inputs.sel).out
+            outputs.out[i] = Nand(a=fromAneg, b=fromBneg).out
+    Mux16Plus = build(mkMux16Plus)
+
+    not_sel0 = Not(in_=inputs.sel[0]).out
+    ab = Mux16Plus(a=inputs.a, b=inputs.b, not_sel=not_sel0, sel=inputs.sel[0]).out
+    cd = Mux16Plus(a=inputs.c, b=inputs.d, not_sel=not_sel0, sel=inputs.sel[0]).out
+    outputs.out = Mux16(a=ab, b=cd, sel=inputs.sel[1]).out    
+
+Mux4Way16 = build(mkMux4Way16)
+
+
+def mkMux8Way16(inputs, outputs):
+    # Share not_sel to save a total of 4 gates:
+    def mkMux16Plus(inputs, outputs):
+        for i in range(16):
+            fromAneg = Nand(a=inputs.a[i], b=inputs.not_sel).out
+            fromBneg = Nand(a=inputs.b[i], b=inputs.sel).out
+            outputs.out[i] = Nand(a=fromAneg, b=fromBneg).out
+    Mux16Plus = build(mkMux16Plus)
+
+    not_sel0 = Not(in_=inputs.sel[0]).out
+    ab = Mux16Plus(a=inputs.a, b=inputs.b, not_sel=not_sel0, sel=inputs.sel[0]).out
+    cd = Mux16Plus(a=inputs.c, b=inputs.d, not_sel=not_sel0, sel=inputs.sel[0]).out
+    ef = Mux16Plus(a=inputs.e, b=inputs.f, not_sel=not_sel0, sel=inputs.sel[0]).out
+    gh = Mux16Plus(a=inputs.g, b=inputs.h, not_sel=not_sel0, sel=inputs.sel[0]).out
+    not_sel1 = Not(in_=inputs.sel[1]).out
+    abcd = Mux16Plus(a=ab, b=cd, not_sel=not_sel1, sel=inputs.sel[1]).out
+    efgh = Mux16Plus(a=ef, b=gh, not_sel=not_sel1, sel=inputs.sel[1]).out
+    outputs.out = Mux16(a=abcd, b=efgh, sel=inputs.sel[2]).out
+            
+Mux8Way16 = build(mkMux8Way16)

--- a/nand/solutions/solved_02.py
+++ b/nand/solutions/solved_02.py
@@ -1,0 +1,120 @@
+"""Solutions for project 02.
+
+SPOILER ALERT: this files contains complete and optimal solutions for all the exercises.
+If you want to solve them on your own, stop reading now!
+"""
+
+from nand import *
+
+from nand.solutions.solved_01 import And, And16, Or, Mux16, Not, Not16, Xor
+
+
+def mkHalfAdder(inputs, outputs):
+    a = inputs.a
+    b = inputs.b
+    
+    nand = Nand(a=a, b=b).out
+
+    # Xor(a, b):
+    nandANand = Nand(a=a, b=nand).out
+    nandBNand = Nand(a=nand, b=b).out
+    outputs.sum = Nand(a=nandANand, b=nandBNand).out
+
+    # And(a, b):
+    outputs.carry = Not(in_=nand).out
+
+HalfAdder = build(mkHalfAdder)
+
+
+def mkFullAdder(inputs, outputs):
+    def mkHalfAdderNot(inputs, outputs):
+        """Half-adder with one less gate by exposing the opposite of carry."""
+        nand = Nand(a=inputs.a, b=inputs.b).out
+        nandANand = Nand(a=inputs.a, b=nand).out
+        nandBNand = Nand(a=nand, b=inputs.b).out
+        outputs.sum = Nand(a=nandANand, b=nandBNand).out
+        outputs.not_carry = nand
+    HalfAdderNot = build(mkHalfAdderNot)
+
+    ab = HalfAdderNot(a=inputs.a, b=inputs.b)
+    abc = HalfAdderNot(a=ab.sum, b=inputs.c)
+    outputs.carry = Nand(a=ab.not_carry, b=abc.not_carry).out
+    outputs.sum = abc.sum
+
+FullAdder = build(mkFullAdder)
+
+
+def mkInc16(inputs, outputs):
+    # Don't even need a whole HalfAdder for the low bit:
+    outputs.out[0] = Not(in_=inputs.in_[0]).out
+    carry = inputs.in_[0]
+    for i in range(1, 16):
+        tmp = HalfAdder(a=carry, b=inputs.in_[i])
+        outputs.out[i] = tmp.sum
+        carry = tmp.carry
+
+Inc16 = build(mkInc16)
+
+
+def mkAdd16(inputs, outputs):
+    a = HalfAdder(a=inputs.a[0], b=inputs.b[0])
+    outputs.out[0] = a.sum
+    for i in range(1, 16):
+        tmp = FullAdder(a=inputs.a[i], b=inputs.b[i], c=a.carry)
+        outputs.out[i] = tmp.sum
+        a = tmp
+
+Add16 = build(mkAdd16)
+
+
+def mkALU(inputs, outputs):
+    x = inputs.x
+    y = inputs.y
+    
+    zx = inputs.zx
+    nx = inputs.nx
+    zy = inputs.zy
+    ny = inputs.ny
+    f  = inputs.f
+    no = inputs.no
+    
+    x_zeroed = Mux16(a=x, b=0, sel=zx).out
+    y_zeroed = Mux16(a=y, b=0, sel=zy).out
+
+    x_inverted = Mux16(a=x_zeroed, b=Not16(in_=x_zeroed).out, sel=nx).out
+    y_inverted = Mux16(a=y_zeroed, b=Not16(in_=y_zeroed).out, sel=ny).out
+    
+    anded = And16(a=x_inverted, b=y_inverted).out
+    added = Add16(a=x_inverted, b=y_inverted).out
+    
+    result = Mux16(a=anded, b=added, sel=f).out
+    result_inverted = Not16(in_=result).out
+    
+    out = Mux16(a=result, b=result_inverted, sel=no).out
+    
+    def mkZero16(inputs, outputs):
+        in_ = inputs.in_
+        outputs.out = And(
+            a=And(a=And(a=And(a=Not(in_=in_[15]).out,
+                              b=Not(in_=in_[14]).out).out,
+                        b=And(a=Not(in_=in_[13]).out,
+                              b=Not(in_=in_[12]).out).out).out,
+                  b=And(a=And(a=Not(in_=in_[11]).out,
+                              b=Not(in_=in_[10]).out).out,
+                        b=And(a=Not(in_=in_[ 9]).out,
+                              b=Not(in_=in_[ 8]).out).out).out).out,
+            b=And(a=And(a=And(a=Not(in_=in_[ 7]).out,
+                              b=Not(in_=in_[ 6]).out).out,
+                        b=And(a=Not(in_=in_[ 5]).out,
+                              b=Not(in_=in_[ 4]).out).out).out,
+                  b=And(a=And(a=Not(in_=in_[ 3]).out,
+                              b=Not(in_=in_[ 2]).out).out,
+                        b=And(a=Not(in_=in_[ 1]).out,
+                              b=Not(in_=in_[ 0]).out).out).out).out).out
+    Zero16 = build(mkZero16)
+    
+    outputs.out = out
+    outputs.zr = Zero16(in_=out).out
+    outputs.ng = out[15]
+    
+ALU = build(mkALU)

--- a/nand/solutions/solved_03.py
+++ b/nand/solutions/solved_03.py
@@ -113,7 +113,7 @@ RAM512 = build(mkRAM512)
 
 
 # Note: here's an implementation which is probably correct, but the resulting chip
-# is so large when it's flattened that there's not much hope of actually simulating it.
+# is so large when it's flattened that it's no fun actually trying to simulate it.
 def mkRAM4K(inputs, outputs):
     def mkRShift9(inputs, outputs):
         outputs.out[0] = inputs.in_[9]
@@ -123,14 +123,14 @@ def mkRAM4K(inputs, outputs):
 
     shifted = RShift9(in_=inputs.address)
     load = DMux8Way(in_=inputs.load, sel=shifted.out)
-    ram0 = RAM64(in_=inputs.in_, load=load.a, address=inputs.address)
-    ram1 = RAM64(in_=inputs.in_, load=load.b, address=inputs.address)
-    ram2 = RAM64(in_=inputs.in_, load=load.c, address=inputs.address)
-    ram3 = RAM64(in_=inputs.in_, load=load.d, address=inputs.address)
-    ram4 = RAM64(in_=inputs.in_, load=load.e, address=inputs.address)
-    ram5 = RAM64(in_=inputs.in_, load=load.f, address=inputs.address)
-    ram6 = RAM64(in_=inputs.in_, load=load.g, address=inputs.address)
-    ram7 = RAM64(in_=inputs.in_, load=load.h, address=inputs.address)
+    ram0 = RAM512(in_=inputs.in_, load=load.a, address=inputs.address)
+    ram1 = RAM512(in_=inputs.in_, load=load.b, address=inputs.address)
+    ram2 = RAM512(in_=inputs.in_, load=load.c, address=inputs.address)
+    ram3 = RAM512(in_=inputs.in_, load=load.d, address=inputs.address)
+    ram4 = RAM512(in_=inputs.in_, load=load.e, address=inputs.address)
+    ram5 = RAM512(in_=inputs.in_, load=load.f, address=inputs.address)
+    ram6 = RAM512(in_=inputs.in_, load=load.g, address=inputs.address)
+    ram7 = RAM512(in_=inputs.in_, load=load.h, address=inputs.address)
     outputs.out = Mux8Way16(a=ram0.out, b=ram1.out, c=ram2.out, d=ram3.out,
                             e=ram4.out, f=ram5.out, g=ram6.out, h=ram7.out,
                             sel=shifted.out).out

--- a/nand/solutions/solved_03.py
+++ b/nand/solutions/solved_03.py
@@ -1,0 +1,162 @@
+"""Solutions for project 03.
+
+SPOILER ALERT: this files contains complete and optimal solutions for all the exercises.
+If you want to solve them on your own, stop reading now!
+"""
+
+from nand import build
+from nand.solutions.solved_01 import *
+from nand.solutions.solved_02 import *
+
+
+def mkMyDFF(inputs, outputs):
+    # Note: provided as a primitive in the Nand to Tetris simulator, but implementing it
+    # from scratch is fun.
+
+    def mkLatch(inputs, outputs):
+        mux = lazy()
+        mux.set(Mux(a=mux.out, b=inputs.in_, sel=inputs.enable))
+        outputs.out = mux.out
+    Latch = build(mkLatch)
+    
+    l1 = Latch(in_=inputs.in_, enable=clock)
+    l2 = Latch(in_=l1.out, enable=Not(in_=clock).out)
+    
+    outputs.out = l2.out
+
+MyDFF = build(mkMyDFF)
+
+
+def mkBit(inputs, outputs):
+    # OK to use DynamicDFF here, for the most efficient result.
+    
+    in_ = inputs.in_
+    load = inputs.load
+    dff = lazy()
+    mux = Mux(a=dff.out, b=inputs.in_, sel=inputs.load)
+    dff.set(DFF(in_=mux.out))
+    outputs.out = dff.out
+
+Bit = build(mkBit)
+
+
+def mkRegister(inputs, outputs):
+    for i in range(16):
+        outputs.out[i] = Bit(in_=inputs.in_[i], load=inputs.load).out
+        
+Register = build(mkRegister)
+
+
+def mkRAM8(inputs, outputs):
+    load = DMux8Way(in_=inputs.load, sel=inputs.address)
+    reg0 = Register(in_=inputs.in_, load=load.a)
+    reg1 = Register(in_=inputs.in_, load=load.b)
+    reg2 = Register(in_=inputs.in_, load=load.c)
+    reg3 = Register(in_=inputs.in_, load=load.d)
+    reg4 = Register(in_=inputs.in_, load=load.e)
+    reg5 = Register(in_=inputs.in_, load=load.f)
+    reg6 = Register(in_=inputs.in_, load=load.g)
+    reg7 = Register(in_=inputs.in_, load=load.h)
+    outputs.out = Mux8Way16(a=reg0.out, b=reg1.out, c=reg2.out, d=reg3.out,
+                            e=reg4.out, f=reg5.out, g=reg6.out, h=reg7.out,
+                            sel=inputs.address).out
+    
+RAM8 = build(mkRAM8)
+
+
+def mkRAM64(inputs, outputs):
+    def mkRShift3(inputs, outputs):
+        outputs.out[0] = inputs.in_[3]
+        outputs.out[1] = inputs.in_[4]
+        outputs.out[2] = inputs.in_[5]
+    RShift3 = build(mkRShift3)
+
+    shifted = RShift3(in_=inputs.address)
+    load = DMux8Way(in_=inputs.load, sel=shifted.out)
+    ram0 = RAM8(in_=inputs.in_, load=load.a, address=inputs.address)
+    ram1 = RAM8(in_=inputs.in_, load=load.b, address=inputs.address)
+    ram2 = RAM8(in_=inputs.in_, load=load.c, address=inputs.address)
+    ram3 = RAM8(in_=inputs.in_, load=load.d, address=inputs.address)
+    ram4 = RAM8(in_=inputs.in_, load=load.e, address=inputs.address)
+    ram5 = RAM8(in_=inputs.in_, load=load.f, address=inputs.address)
+    ram6 = RAM8(in_=inputs.in_, load=load.g, address=inputs.address)
+    ram7 = RAM8(in_=inputs.in_, load=load.h, address=inputs.address)
+    outputs.out = Mux8Way16(a=ram0.out, b=ram1.out, c=ram2.out, d=ram3.out,
+                            e=ram4.out, f=ram5.out, g=ram6.out, h=ram7.out,
+                            sel=shifted.out).out
+
+RAM64 = build(mkRAM64)
+
+
+def mkRAM512(inputs, outputs):
+    def mkRShift6(inputs, outputs):
+        outputs.out[0] = inputs.in_[6]
+        outputs.out[1] = inputs.in_[7]
+        outputs.out[2] = inputs.in_[8]
+    RShift6 = build(mkRShift6)
+
+    shifted = RShift6(in_=inputs.address)
+    load = DMux8Way(in_=inputs.load, sel=shifted.out)
+    ram0 = RAM64(in_=inputs.in_, load=load.a, address=inputs.address)
+    ram1 = RAM64(in_=inputs.in_, load=load.b, address=inputs.address)
+    ram2 = RAM64(in_=inputs.in_, load=load.c, address=inputs.address)
+    ram3 = RAM64(in_=inputs.in_, load=load.d, address=inputs.address)
+    ram4 = RAM64(in_=inputs.in_, load=load.e, address=inputs.address)
+    ram5 = RAM64(in_=inputs.in_, load=load.f, address=inputs.address)
+    ram6 = RAM64(in_=inputs.in_, load=load.g, address=inputs.address)
+    ram7 = RAM64(in_=inputs.in_, load=load.h, address=inputs.address)
+    outputs.out = Mux8Way16(a=ram0.out, b=ram1.out, c=ram2.out, d=ram3.out,
+                            e=ram4.out, f=ram5.out, g=ram6.out, h=ram7.out,
+                            sel=shifted.out).out
+
+RAM512 = build(mkRAM512)
+
+
+# Note: here's an implementation which is probably correct, but the resulting chip
+# is so large when it's flattened that there's not much hope of actually simulating it.
+def mkRAM4K(inputs, outputs):
+    def mkRShift9(inputs, outputs):
+        outputs.out[0] = inputs.in_[9]
+        outputs.out[1] = inputs.in_[10]
+        outputs.out[2] = inputs.in_[11]
+    RShift9 = build(mkRShift9)
+
+    shifted = RShift9(in_=inputs.address)
+    load = DMux8Way(in_=inputs.load, sel=shifted.out)
+    ram0 = RAM64(in_=inputs.in_, load=load.a, address=inputs.address)
+    ram1 = RAM64(in_=inputs.in_, load=load.b, address=inputs.address)
+    ram2 = RAM64(in_=inputs.in_, load=load.c, address=inputs.address)
+    ram3 = RAM64(in_=inputs.in_, load=load.d, address=inputs.address)
+    ram4 = RAM64(in_=inputs.in_, load=load.e, address=inputs.address)
+    ram5 = RAM64(in_=inputs.in_, load=load.f, address=inputs.address)
+    ram6 = RAM64(in_=inputs.in_, load=load.g, address=inputs.address)
+    ram7 = RAM64(in_=inputs.in_, load=load.h, address=inputs.address)
+    outputs.out = Mux8Way16(a=ram0.out, b=ram1.out, c=ram2.out, d=ram3.out,
+                            e=ram4.out, f=ram5.out, g=ram6.out, h=ram7.out,
+                            sel=shifted.out).out
+
+RAM4K = build(mkRAM4K)
+
+
+# Note: this is just wrapping the built-in RAM primitive, so we can test that its interface 
+# is the same as the rest.
+RAM16K = RAM(14)
+"""14 address bits yields a 16K memory."""
+
+
+def mkPC(inputs, outputs):
+    in_ = inputs.in_
+    load = inputs.load
+    inc = inputs.inc
+    reset = inputs.reset
+    
+    reseted = lazy()
+    pc = Register(in_=reseted.out, load=1)
+    
+    inced = Mux16(a=pc.out, b=Inc16(in_=pc.out).out, sel=inc)
+    loaded = Mux16(a=inced.out, b=in_, sel=load)
+    reseted.set(Mux16(a=loaded.out, b=0, sel=reset))
+    
+    outputs.out = pc.out
+
+PC = build(mkPC)

--- a/nand/solutions/solved_04.py
+++ b/nand/solutions/solved_04.py
@@ -1,0 +1,91 @@
+"""Solutions for project 04.
+
+SPOILER ALERT: this files contains complete solutions for all the exercises.
+If you want to solve them on your own, stop reading now!
+"""
+
+# Disclaimer: these solutions aren't especially elegant.
+
+
+MULT_ASM = """
+  // Initialize R2 to 0
+  @R2
+  M=0
+  
+  // Test for R1 == 0 and exit early
+  @R1
+  D=M
+  @halt
+  D;JLE
+  
+(loop)
+  @R0
+  D=M
+  @halt
+  D;JLE
+
+  // Add R1 to R2:
+  @1
+  D=M
+  @R2
+  M=D+M
+  
+  // Subtract 1 from R0 (in place)
+  @R0
+  M=M-1
+  
+  @loop
+  0;JMP
+
+(halt)
+    
+""".split('\n')
+
+
+FILL_ASM = """
+(top)
+  @KEYBOARD
+  D=M
+  @black
+  D;JNE
+
+(white)
+  @R0
+  M=0
+  @start
+  0;JMP
+
+(black)
+  @R0
+  M=-1
+
+(start)
+  // Initialize R1 to point to the first word of screen RAM
+  @SCREEN
+  D=A
+  @R1
+  M=D
+
+(loop)
+  // Test if R1 is at the end (i.e. points to @KEYBOARD); if so, back to the beginning
+  @R1
+  D=M
+  @KEYBOARD
+  D=D-A
+  @top
+  D;JGE
+  
+  // Fill the current word with the appropriate pixels:
+  @R0
+  D=M
+  @R1
+  A=M
+  M=D
+  
+  // Increment R1
+  @R1
+  M=M+1
+
+  @loop
+  0;JMP
+""".split('\n')

--- a/nand/solutions/solved_05.py
+++ b/nand/solutions/solved_05.py
@@ -1,0 +1,98 @@
+"""Solutions for project 05.
+
+SPOILER ALERT: this files contains complete and optimal solutions for all the exercises.
+If you want to solve them on your own, stop reading now!
+"""
+
+from nand import RAM, ROM, Input, build, lazy
+from nand.solutions.solved_01 import *
+from nand.solutions.solved_02 import *
+from nand.solutions.solved_03 import *
+
+
+def mkMemorySystem(inputs, outputs):
+    in_ = inputs.in_
+    load = inputs.load
+    address = inputs.address
+
+    def mkShift13(inputs, outputs):
+        outputs.out[0] = inputs.in_[13]
+        outputs.out[1] = inputs.in_[14]
+    Shift13 = build(mkShift13)
+
+    def mkMask14(inputs, outputs):
+        for i in range(14):
+            outputs.out[i] = inputs.in_[i]
+    Mask14 = build(mkMask14)
+
+    bank = Shift13(in_=address).out
+    load_bank = DMux4Way(in_=load, sel=bank)
+    address14 = Mask14(in_=address).out
+
+    # addresses 0x0000 to 0x3FFF
+    ram = RAM(14)(in_=in_, load=Or(a=load_bank.a, b=load_bank.b).out, address=address14)
+
+    # addresses 0x4000 to 0x5FFFF
+    # TODO: connect to pygame display
+    # note: bit 13 is definitely zero, so address[0..13] == address[0..12]
+    screen = RAM(13)(in_=in_, load=load_bank.c, address=address14)
+
+    # address 0x6000
+    # TODO: keyboard = Keyboard()
+    keyboard = Input()
+
+    outputs.out = Mux4Way16(a=ram.out, b=ram.out, c=screen.out, d=keyboard.out, sel=bank).out
+
+MemorySystem = build(mkMemorySystem)
+
+
+def mkCPU(inputs, outputs):
+    inM = inputs.inM                 # M value input (M = contents of RAM[A])
+    instruction = inputs.instruction # Instruction for execution
+    reset = inputs.reset             # Signals whether to re-start the current
+                                     # program (reset==1) or continue executing
+                                     # the current program (reset==0).
+
+    i, _, _, a, c5, c4, c3, c2, c1, c0, da, dd, dm, jlt, jeq, jgt = [instruction[j] for j in reversed(range(16))]
+
+    not_i = Not(in_=i).out
+
+    alu = lazy()
+    a_reg = Register(in_=Mux16(a=instruction, b=alu.out, sel=i).out, load=Or(a=not_i, b=da).out)
+    d_reg = Register(in_=alu.out, load=And(a=i, b=dd).out)
+    jump = And(a=i,
+               b=Or(a=     And(a=alu.ng, b=jlt).out,                      # lt
+                    b=Or(a=And(a=alu.zr, b=jeq).out,                      # eq
+                         b=And(a=And(a=Not(in_=alu.ng).out, b=Not(in_=alu.zr).out).out, b=jgt).out  # gt
+                         ).out
+                    ).out
+              ).out
+    pc = PC(in_=a_reg.out, load=jump, inc=1, reset=reset)
+    alu.set(ALU(x=d_reg.out, y=Mux16(a=a_reg.out, b=inM, sel=a).out,
+                zx=c5, nx=c4, zy=c3, ny=c2, f=c1, no=c0))
+
+
+    outputs.outM = alu.out                   # M value output
+    outputs.writeM = And(a=dm, b=i).out      # Write to M?
+    outputs.addressM = a_reg.out             # Address in data memory (of M) (latched)
+    outputs.pc = pc.out                      # address of next instruction (latched)
+
+CPU = build(mkCPU)
+
+
+def mkComputer(inputs, outputs):
+    reset = inputs.reset
+    
+    cpu = lazy()
+
+    rom = ROM(15)(address=cpu.pc)
+
+    mem = MemorySystem(in_=cpu.outM, load=cpu.writeM, address=cpu.addressM)
+
+    cpu.set(CPU(inM=mem.out, instruction=rom.out, reset=reset))
+
+    # HACK: need some dependency to force the whole thing to be synthesized.
+    # Exposing the PC also makes it easy to observe what's happening in a dumb way.
+    outputs.pc = cpu.pc
+
+Computer = build(mkComputer)

--- a/nand/solutions/solved_06.py
+++ b/nand/solutions/solved_06.py
@@ -1,0 +1,142 @@
+"""Solutions for project 06.
+
+SPOILER ALERT: this files contains a complete assembler.
+If you want to solve them on your own, stop reading now!
+"""
+
+# Disclaimer: this implementation was written quickly and seems to work, but those are the only good
+# things that can be said about it.
+
+import re
+
+ALU_CONTROL = {
+    # These match the bit patterns used in Add and Max:
+    "0":   0b101010,
+    "A":   0b110000,
+    "D":   0b001100,
+    "D-A": 0b010011,
+    "D+A": 0b000010,
+    "1":   0b111111,
+    "-1":  0b111010,
+    "D&A": 0b000000,
+    "D|A": 0b010101,
+    "A-D": 0b000111,
+    "!D":  0b001011,
+    "!A":  0b110001,
+    "D+1": 0b011111,
+    "A+1": 0b110111,
+    "D-1": 0b001110,
+    "A-1": 0b110010,
+    "-D":  0b001111,
+    "-A":  0b110011,
+}
+
+JMP_CONTROL = {
+    "LT": 0b100,
+    "LE": 0b110,
+    "EQ": 0b010,
+    "NE": 0b101,
+    "GE": 0b011,
+    "GT": 0b001,
+    "MP": 0b111,
+}
+
+BUILTIN_SYMBOLS = {
+    **{
+        "SP":       0,
+        "LCL":      1,
+        "ARG":      2,
+        "THIS":     3,
+        "THAT":     4,
+        "SCREEN":   0x4000,
+        "KEYBOARD": 0x6000,
+    },
+    **{ f"R{i}": i for i in range(16)}
+}
+
+
+def parse_op(string):
+    """Parse a single assembly op directly to the corresponding Hack instruction word.
+    
+    The op may be a numeric symbol (an A-command) or a C-command, but not a reference
+    to a symbol or variable.
+    """
+    
+    m = re.match(r"@((?:0x)?\d+)", string)
+    if m:
+        return eval(m.group(1))
+    else:
+        m = re.match(r"(?:([ADM]+)=)?([^;]+)(?:;J(..))?", string)
+        if m:
+            dest_str = m.group(1) or ""
+            dest = 0
+            if 'A' in dest_str:
+                dest |= 0b100
+            if 'D' in dest_str:
+                dest |= 0b010
+            if 'M' in dest_str:
+                dest |= 0b001
+        
+            alu_str = m.group(2).replace('M', 'A')
+            if alu_str in ALU_CONTROL:
+                alu = ALU_CONTROL[alu_str]
+                m_for_a = int('M' in m.group(2))
+            else:
+                raise Exception(f"unrecognized alu op: {m.group(2)}")
+            
+            jmp_str = m.group(3)
+            if jmp_str is None:
+                jmp = 0
+            elif jmp_str in JMP_CONTROL:
+                jmp = JMP_CONTROL[jmp_str]
+            else:
+                raise Exception(f"unrecognized jump: J{m.group(3)}")
+        
+            return (0b111 << 13) | (m_for_a << 12) | (alu << 6) | (dest << 3) | jmp
+        else:
+            raise Exception(f"unrecognized: {line}")
+
+
+def load_file(f):
+    """Load the lines of file and parse them as assembly commands, accounting for
+    builtin symbols, labels, and variables.
+    
+    "//" denotes a comment and is ignored, along with the remainder of the line.
+    Leading and trailing white space on each line is ignored.
+    After comments and white space are stripped, blank lines are ignored.
+    """
+    
+    code_lines = []
+    for line in f:
+        m = re.match(r"([^/]*)(?://.*)?", line)
+        if m:
+            string = m.group(1).strip()
+        else:
+            string = line.strip()
+        
+        if string:
+            code_lines.append(string)
+    
+    symbols = BUILTIN_SYMBOLS.copy()
+    loc = 0
+    for line in code_lines:
+        m = re.match(r"\((.*)\)", line)
+        if m:
+            symbols[m.group(1)] = loc
+        else:
+            loc += 1
+        
+    ops = []
+    next_variable = 16
+    for line in code_lines:
+        if "(" not in line:
+            m = re.match(r"@(\D.*)", line)
+            if m:
+                symbol_str = m.group(1)
+                if symbol_str not in symbols:
+                    symbols[symbol_str] = next_variable
+                    next_variable += 1
+                ops.append(symbols[symbol_str])
+            else:
+                ops.append(parse_op(line))
+    return ops

--- a/nand/test_syntax.py
+++ b/nand/test_syntax.py
@@ -199,7 +199,49 @@ def test_error_unexpected_arg():
 
     with pytest.raises(SyntaxError) as exc_info:
         Err.constr()
-    assert str(exc_info.value) == "Unexpected argument: c"
+    assert str(exc_info.value) == "Unrecognized input: 'c'"
+
+
+def test_error_missing_arg():
+    def mkAnd(inputs, outputs):
+        outputs.out = Nand(a=inputs.a, b=inputs.b).out
+    And = build(mkAnd)
+
+    def mkWrap(inputs, outputs):
+        outputs.out = And(a=inputs.in_).out  # Missing `b=` here
+    Wrap = build(mkWrap)
+
+    with pytest.raises(SyntaxError) as exc_info:
+        chip = Wrap.constr()
+    assert str(exc_info.value) == "Missing input(s): {'b'}"
+
+
+def test_error_unknown_input():
+    def mkAnd(inputs, outputs):
+        outputs.out = Nand(a=inputs.a, b=inputs.b).out
+    And = build(mkAnd)
+
+    def mkWrap(inputs, outputs):
+        outputs.out = And(a=inputs.in_, b=inputs.in_, c=inputs.in_).out  # Extra input: `c`
+    Wrap = build(mkWrap)
+
+    with pytest.raises(SyntaxError) as exc_info:
+        chip = Wrap.constr()
+    assert str(exc_info.value) == "Unrecognized input: 'c'"
+
+
+def test_error_unknown_output():
+    def mkAnd(inputs, outputs):
+        outputs.out = Nand(a=inputs.a, b=inputs.b).out
+    And = build(mkAnd)
+
+    def mkWrap(inputs, outputs):
+        outputs.out = And(a=inputs.in_, b=inputs.in_).result  # Wrong name
+    Wrap = build(mkWrap)
+
+    with pytest.raises(SyntaxError) as exc_info:
+        chip = Wrap.constr()
+    assert str(exc_info.value) == "Unrecognized output: 'result'"
 
 
 def test_error_ref_expected_for_input():

--- a/project_01.py
+++ b/project_01.py
@@ -1,3 +1,5 @@
+# See https://www.nand2tetris.org/project01
+
 from nand import Nand, build
 
 # SOLVERS: remove this import to get started

--- a/project_01.py
+++ b/project_01.py
@@ -1,10 +1,16 @@
 from nand import *
 
+# SOLVERS: remove this import to get started
+from nand.solutions import solved_01
+
 
 def mkNot(inputs, outputs):
     in_ = inputs.in_
-    n = Nand(a=in_, b=in_)
-    outputs.out = n.out
+    
+    # SOLVERS: replace this with a Nand
+    n1 = solved_01.Not(in_=in_)
+    
+    outputs.out = n1.out
 
 Not = build(mkNot)
 
@@ -12,10 +18,11 @@ Not = build(mkNot)
 def mkOr(inputs, outputs):
     a = inputs.a
     b = inputs.b
-    notA = Not(in_=a)
-    notB = Not(in_=b)
-    notNotBoth = Nand(a=notA.out, b=notB.out)
-    outputs.out = notNotBoth.out
+    
+    # SOLVERS: replace this with one or more Nands and Nots
+    n1 = solved_01.Or(a=a, b=b)
+    
+    outputs.out = n1.out
 
 Or = build(mkOr)
 
@@ -23,8 +30,11 @@ Or = build(mkOr)
 def mkAnd(inputs, outputs):
     a = inputs.a
     b = inputs.b
-    notAandB = Nand(a=a, b=b).out
-    outputs.out = Not(in_=notAandB).out
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_01.And(a=a, b=b)
+    
+    outputs.out = n1.out
 
 And = build(mkAnd)
 
@@ -32,10 +42,11 @@ And = build(mkAnd)
 def mkXor(inputs, outputs):
     a = inputs.a
     b = inputs.b
-    nand = Nand(a=a, b=b).out
-    nandANand = Nand(a=a, b=nand).out
-    nandBNand = Nand(a=nand, b=b).out
-    outputs.out = Nand(a=nandANand, b=nandBNand).out
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_01.Xor(a=a, b=b)
+    
+    outputs.out = n1.out
 
 Xor = build(mkXor)
 
@@ -44,9 +55,11 @@ def mkMux(inputs, outputs):
     a = inputs.a
     b = inputs.b
     sel = inputs.sel
-    fromAneg = Nand(a=a, b=Not(in_=sel).out).out
-    fromBneg = Nand(a=b, b=sel).out
-    outputs.out = Nand(a=fromAneg, b=fromBneg).out
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_01.Mux(a=a, b=b, sel=sel)
+
+    outputs.out = n1.out
 
 Mux = build(mkMux)
 
@@ -54,126 +67,117 @@ Mux = build(mkMux)
 def mkDMux(inputs, outputs):
     in_ = inputs.in_
     sel = inputs.sel
-    outputs.a = And(a=in_, b=Not(in_=sel).out).out
-    outputs.b = And(a=in_, b=sel).out
+    
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_01.DMux(in_=in_, sel=sel)
+    
+    outputs.a = n1.a
+    outputs.b = n1.b
 
 DMux = build(mkDMux)
 
 
 def mkDMux4Way(inputs, outputs):
-    def mkDMuxPlus(inputs, outputs):
-        outputs.a = And(a=inputs.in_, b=inputs.not_sel).out
-        outputs.b = And(a=inputs.in_, b=inputs.sel).out
-    DMuxPlus = build(mkDMuxPlus)
-
-    # TODO: optimal?
     in_ = inputs.in_
     sel = inputs.sel
-    lo = DMux(in_=in_, sel=sel[0])
-    sel1 = sel[1]
-    not_sel1 = Not(in_=sel1).out
-    dmux1 = DMuxPlus(in_=lo.a, not_sel=not_sel1, sel=sel1)
-    dmux2 = DMuxPlus(in_=lo.b, not_sel=not_sel1, sel=sel1)
-    outputs.a = dmux1.a
-    outputs.b = dmux2.a
-    outputs.c = dmux1.b
-    outputs.d = dmux2.b
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    # Hint: use sel[0] and sel[1] to extract each bit
+    n1 = solved_01.DMux4Way(in_=in_, sel=sel)
+
+    outputs.a = n1.a
+    outputs.b = n1.b
+    outputs.c = n1.c
+    outputs.d = n1.d
     
 DMux4Way = build(mkDMux4Way)
 
 
 def mkDMux8Way(inputs, outputs):
-    def mkDMuxPlus(inputs, outputs):
-        outputs.a = And(a=inputs.in_, b=inputs.not_sel).out
-        outputs.b = And(a=inputs.in_, b=inputs.sel).out
-    DMuxPlus = build(mkDMuxPlus)
-
-    # TODO: optimal?
-    # TODO: implement bit slice syntax and use DMux4Way?
     in_ = inputs.in_
     sel = inputs.sel
-    sel1 = sel[1]
-    not_sel1 = Not(in_=sel1).out
-    sel2 = sel[2]
-    not_sel2 = Not(in_=sel2).out
-    lo = DMux(in_=in_, sel=sel[0])
-    lo0 = DMuxPlus(in_=lo.a, not_sel=not_sel1, sel=sel1)
-    lo1 = DMuxPlus(in_=lo.b, not_sel=not_sel1, sel=sel1)
-    dmux1 = DMuxPlus(in_=lo0.a, not_sel=not_sel2, sel=sel2)
-    dmux2 = DMuxPlus(in_=lo1.a, not_sel=not_sel2, sel=sel2)
-    dmux3 = DMuxPlus(in_=lo0.b, not_sel=not_sel2, sel=sel2)
-    dmux4 = DMuxPlus(in_=lo1.b, not_sel=not_sel2, sel=sel2)
-    outputs.a = dmux1.a
-    outputs.b = dmux2.a
-    outputs.c = dmux3.a
-    outputs.d = dmux4.a
-    outputs.e = dmux1.b
-    outputs.f = dmux2.b
-    outputs.g = dmux3.b
-    outputs.h = dmux4.b
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_01.DMux8Way(in_=in_, sel=sel)
+
+    outputs.a = n1.a
+    outputs.b = n1.b
+    outputs.c = n1.c
+    outputs.d = n1.d
+    outputs.e = n1.e
+    outputs.f = n1.f
+    outputs.g = n1.g
+    outputs.h = n1.h
     
 DMux8Way = build(mkDMux8Way)
 
 
 def mkNot16(inputs, outputs):
     in_ = inputs.in_
-    for i in range(16):
-        outputs.out[i] = Not(in_=in_[i]).out
+    
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    # Hint: use outputs.out[0]... to connect each bit of the output
+    n1 = solved_01.Not16(in_=in_)
+    
+    outputs.out = n1.out
 
 Not16 = build(mkNot16)
         
 
 def mkAnd16(inputs, outputs):
-    for i in range(16):
-        outputs.out[i] = And(a=inputs.a[i], b=inputs.b[i]).out
+    a = inputs.a
+    b = inputs.b
+    
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_01.And16(a=a, b=b)
+    
+    outputs.out = n1.out
 
 And16 = build(mkAnd16)
 
 
 def mkMux16(inputs, outputs):
-    not_sel = Not(in_=inputs.sel).out
-    for i in range(16):
-        fromAneg = Nand(a=inputs.a[i], b=not_sel).out
-        fromBneg = Nand(a=inputs.b[i], b=inputs.sel).out
-        outputs.out[i] = Nand(a=fromAneg, b=fromBneg).out
+    a = inputs.a
+    b = inputs.b
+    sel = inputs.sel
+    
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_01.Mux16(a=a, b=b, sel=sel)
+    
+    outputs.out = n1.out
 
 Mux16 = build(mkMux16)
 
 
 def mkMux4Way16(inputs, outputs):
-    # Share not_sel to save one gate:
-    def mkMux16Plus(inputs, outputs):
-        for i in range(16):
-            fromAneg = Nand(a=inputs.a[i], b=inputs.not_sel).out
-            fromBneg = Nand(a=inputs.b[i], b=inputs.sel).out
-            outputs.out[i] = Nand(a=fromAneg, b=fromBneg).out
-    Mux16Plus = build(mkMux16Plus)
-
-    not_sel0 = Not(in_=inputs.sel[0]).out
-    ab = Mux16Plus(a=inputs.a, b=inputs.b, not_sel=not_sel0, sel=inputs.sel[0]).out
-    cd = Mux16Plus(a=inputs.c, b=inputs.d, not_sel=not_sel0, sel=inputs.sel[0]).out
-    outputs.out = Mux16(a=ab, b=cd, sel=inputs.sel[1]).out    
+    a = inputs.a
+    b = inputs.b
+    c = inputs.c
+    d = inputs.d
+    sel = inputs.sel
+    
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_01.Mux4Way16(a=a, b=b, c=c, d=d, sel=sel)
+    
+    outputs.out = n1.out
 
 Mux4Way16 = build(mkMux4Way16)
 
 
 def mkMux8Way16(inputs, outputs):
-    # Share not_sel to save a total of 4 gates:
-    def mkMux16Plus(inputs, outputs):
-        for i in range(16):
-            fromAneg = Nand(a=inputs.a[i], b=inputs.not_sel).out
-            fromBneg = Nand(a=inputs.b[i], b=inputs.sel).out
-            outputs.out[i] = Nand(a=fromAneg, b=fromBneg).out
-    Mux16Plus = build(mkMux16Plus)
-
-    not_sel0 = Not(in_=inputs.sel[0]).out
-    ab = Mux16Plus(a=inputs.a, b=inputs.b, not_sel=not_sel0, sel=inputs.sel[0]).out
-    cd = Mux16Plus(a=inputs.c, b=inputs.d, not_sel=not_sel0, sel=inputs.sel[0]).out
-    ef = Mux16Plus(a=inputs.e, b=inputs.f, not_sel=not_sel0, sel=inputs.sel[0]).out
-    gh = Mux16Plus(a=inputs.g, b=inputs.h, not_sel=not_sel0, sel=inputs.sel[0]).out
-    not_sel1 = Not(in_=inputs.sel[1]).out
-    abcd = Mux16Plus(a=ab, b=cd, not_sel=not_sel1, sel=inputs.sel[1]).out
-    efgh = Mux16Plus(a=ef, b=gh, not_sel=not_sel1, sel=inputs.sel[1]).out
-    outputs.out = Mux16(a=abcd, b=efgh, sel=inputs.sel[2]).out
+    a = inputs.a
+    b = inputs.b
+    c = inputs.c
+    d = inputs.d
+    e = inputs.e
+    f = inputs.f
+    g = inputs.g
+    h = inputs.h
+    sel = inputs.sel
+    
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_01.Mux8Way16(a=a, b=b, c=c, d=d, e=e, f=f, g=g, h=h, sel=sel)
+    
+    outputs.out = n1.out
             
 Mux8Way16 = build(mkMux8Way16)

--- a/project_01.py
+++ b/project_01.py
@@ -1,4 +1,4 @@
-from nand import *
+from nand import Nand, build
 
 # SOLVERS: remove this import to get started
 from nand.solutions import solved_01

--- a/project_02.py
+++ b/project_02.py
@@ -42,7 +42,7 @@ def mkInc16(inputs, outputs):
     outputs.out[0] = Not(in_=inputs.in_[0]).out
     carry = inputs.in_[0]
     for i in range(1, 16):
-        tmp = HalfAdder(a=inputs.in_[i], b=carry)
+        tmp = HalfAdder(a=carry, b=inputs.in_[i])
         outputs.out[i] = tmp.sum
         carry = tmp.carry
 

--- a/project_02.py
+++ b/project_02.py
@@ -1,4 +1,4 @@
-from nand import *
+from nand import Nand, build
 from project_01 import And, And16, Or, Mux16, Not, Not16, Xor
 
 # SOLVERS: remove this import to get started

--- a/project_02.py
+++ b/project_02.py
@@ -1,3 +1,5 @@
+# See https://www.nand2tetris.org/project02
+
 from nand import Nand, build
 from project_01 import And, And16, Or, Mux16, Not, Not16, Xor
 

--- a/project_02.py
+++ b/project_02.py
@@ -1,61 +1,56 @@
 from nand import *
 from project_01 import And, And16, Or, Mux16, Not, Not16, Xor
 
+# SOLVERS: remove this import to get started
+from nand.solutions import solved_02
+
 
 def mkHalfAdder(inputs, outputs):
     a = inputs.a
     b = inputs.b
-    
-    nand = Nand(a=a, b=b).out
 
-    # Xor(a, b):
-    nandANand = Nand(a=a, b=nand).out
-    nandBNand = Nand(a=nand, b=b).out
-    outputs.sum = Nand(a=nandANand, b=nandBNand).out
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_02.HalfAdder(a=a, b=b)
 
-    # And(a, b):
-    outputs.carry = Not(in_=nand).out
+    outputs.sum = n1.sum
+    outputs.carry = n1.carry
 
 HalfAdder = build(mkHalfAdder)
 
 
 def mkFullAdder(inputs, outputs):
-    def mkHalfAdderNot(inputs, outputs):
-        """Half-adder with one less gate by exposing the opposite of carry."""
-        nand = Nand(a=inputs.a, b=inputs.b).out
-        nandANand = Nand(a=inputs.a, b=nand).out
-        nandBNand = Nand(a=nand, b=inputs.b).out
-        outputs.sum = Nand(a=nandANand, b=nandBNand).out
-        outputs.not_carry = nand
-    HalfAdderNot = build(mkHalfAdderNot)
+    a = inputs.a
+    b = inputs.b
+    c = inputs.c
 
-    ab = HalfAdderNot(a=inputs.a, b=inputs.b)
-    abc = HalfAdderNot(a=ab.sum, b=inputs.c)
-    outputs.carry = Nand(a=ab.not_carry, b=abc.not_carry).out
-    outputs.sum = abc.sum
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_02.FullAdder(a=a, b=b, c=c)
+
+    outputs.sum = n1.sum
+    outputs.carry = n1.carry
 
 FullAdder = build(mkFullAdder)
 
 
 def mkInc16(inputs, outputs):
-    # Don't even need a whole HalfAdder for the low bit:
-    outputs.out[0] = Not(in_=inputs.in_[0]).out
-    carry = inputs.in_[0]
-    for i in range(1, 16):
-        tmp = HalfAdder(a=carry, b=inputs.in_[i])
-        outputs.out[i] = tmp.sum
-        carry = tmp.carry
+    in_ = inputs.in_
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_02.Inc16(in_=in_)
+
+    outputs.out = n1.out
 
 Inc16 = build(mkInc16)
 
 
 def mkAdd16(inputs, outputs):
-    a = HalfAdder(a=inputs.a[0], b=inputs.b[0])
-    outputs.out[0] = a.sum
-    for i in range(1, 16):
-        tmp = FullAdder(a=inputs.a[i], b=inputs.b[i], c=a.carry)
-        outputs.out[i] = tmp.sum
-        a = tmp
+    a = inputs.a
+    b = inputs.b
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_02.Add16(a=a, b=b)
+
+    outputs.out = n1.out
 
 Add16 = build(mkAdd16)
 
@@ -63,51 +58,19 @@ Add16 = build(mkAdd16)
 def mkALU(inputs, outputs):
     x = inputs.x
     y = inputs.y
-    
+
     zx = inputs.zx
     nx = inputs.nx
     zy = inputs.zy
     ny = inputs.ny
     f  = inputs.f
     no = inputs.no
-    
-    x_zeroed = Mux16(a=x, b=0, sel=zx).out
-    y_zeroed = Mux16(a=y, b=0, sel=zy).out
 
-    x_inverted = Mux16(a=x_zeroed, b=Not16(in_=x_zeroed).out, sel=nx).out
-    y_inverted = Mux16(a=y_zeroed, b=Not16(in_=y_zeroed).out, sel=ny).out
-    
-    anded = And16(a=x_inverted, b=y_inverted).out
-    added = Add16(a=x_inverted, b=y_inverted).out
-    
-    result = Mux16(a=anded, b=added, sel=f).out
-    result_inverted = Not16(in_=result).out
-    
-    out = Mux16(a=result, b=result_inverted, sel=no).out
-    
-    def mkZero16(inputs, outputs):
-        in_ = inputs.in_
-        outputs.out = And(
-            a=And(a=And(a=And(a=Not(in_=in_[15]).out,
-                              b=Not(in_=in_[14]).out).out,
-                        b=And(a=Not(in_=in_[13]).out,
-                              b=Not(in_=in_[12]).out).out).out,
-                  b=And(a=And(a=Not(in_=in_[11]).out,
-                              b=Not(in_=in_[10]).out).out,
-                        b=And(a=Not(in_=in_[ 9]).out,
-                              b=Not(in_=in_[ 8]).out).out).out).out,
-            b=And(a=And(a=And(a=Not(in_=in_[ 7]).out,
-                              b=Not(in_=in_[ 6]).out).out,
-                        b=And(a=Not(in_=in_[ 5]).out,
-                              b=Not(in_=in_[ 4]).out).out).out,
-                  b=And(a=And(a=Not(in_=in_[ 3]).out,
-                              b=Not(in_=in_[ 2]).out).out,
-                        b=And(a=Not(in_=in_[ 1]).out,
-                              b=Not(in_=in_[ 0]).out).out).out).out).out
-    Zero16 = build(mkZero16)
-    
-    outputs.out = out
-    outputs.zr = Zero16(in_=out).out
-    outputs.ng = out[15]
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_02.ALU(x=x, y=y, zx=zx, nx=nx, zy=zy, ny=ny, f=f, no=no)
+
+    outputs.out = n1.out
+    outputs.zr = n1.zr
+    outputs.ng = n1.ng
     
 ALU = build(mkALU)

--- a/project_03.py
+++ b/project_03.py
@@ -1,3 +1,5 @@
+# See https://www.nand2tetris.org/project03
+
 from nand import build, clock
 
 from project_01 import *

--- a/project_03.py
+++ b/project_03.py
@@ -1,122 +1,97 @@
-from nand import build
+from nand import build, clock
+
 from project_01 import *
 from project_02 import *
+
+# SOLVERS: remove this import to get started
+from nand.solutions import solved_03
 
 
 def mkMyDFF(inputs, outputs):
     # Note: provided as a primitive in the Nand to Tetris simulator, but implementing it
     # from scratch is fun.
 
-    def mkLatch(inputs, outputs):
-        mux = lazy()
-        mux.set(Mux(a=mux.out, b=inputs.in_, sel=inputs.enable))
-        outputs.out = mux.out
-    Latch = build(mkLatch)
-    
-    l1 = Latch(in_=inputs.in_, enable=clock)
-    l2 = Latch(in_=l1.out, enable=Not(in_=clock).out)
-    
-    outputs.out = l2.out
+    in_ = inputs.in_
+    enable = inputs.enable
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    # Hint: you can use `clock` as an input to any component.
+    n1 = solved_03.MyDFF(in_=in_)
+
+    outputs.out = n1.out
 
 MyDFF = build(mkMyDFF)
 
 
 def mkBit(inputs, outputs):
-    # OK to use DynamicDFF here, for the most efficient result.
-    
+    # OK to use the primitive DFF here, for the most efficient result.
+
     in_ = inputs.in_
     load = inputs.load
-    dff = lazy()
-    mux = Mux(a=dff.out, b=inputs.in_, sel=inputs.load)
-    dff.set(DFF(in_=mux.out))
-    outputs.out = dff.out
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_03.Bit(in_=in_, load=load)
+
+    outputs.out = n1.out
 
 Bit = build(mkBit)
 
 
 def mkRegister(inputs, outputs):
-    for i in range(16):
-        outputs.out[i] = Bit(in_=inputs.in_[i], load=inputs.load).out
-        
+    in_ = inputs.in_
+    load = inputs.load
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_03.Register(in_=in_, load=load)
+
+    outputs.out = n1.out
+
 Register = build(mkRegister)
 
 
 def mkRAM8(inputs, outputs):
-    load = DMux8Way(in_=inputs.load, sel=inputs.address)
-    reg0 = Register(in_=inputs.in_, load=load.a)
-    reg1 = Register(in_=inputs.in_, load=load.b)
-    reg2 = Register(in_=inputs.in_, load=load.c)
-    reg3 = Register(in_=inputs.in_, load=load.d)
-    reg4 = Register(in_=inputs.in_, load=load.e)
-    reg5 = Register(in_=inputs.in_, load=load.f)
-    reg6 = Register(in_=inputs.in_, load=load.g)
-    reg7 = Register(in_=inputs.in_, load=load.h)
-    outputs.out = Mux8Way16(a=reg0.out, b=reg1.out, c=reg2.out, d=reg3.out,
-                            e=reg4.out, f=reg5.out, g=reg6.out, h=reg7.out,
-                            sel=inputs.address).out
-    
+    in_ = inputs.in_
+    load = inputs.load
+    address = inputs.address
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_03.RAM8(in_=in_, load=load, address=address)
+
+    outputs.out = n1.out
+
 RAM8 = build(mkRAM8)
 
 
 def mkRAM64(inputs, outputs):
-    def mkRShift3(inputs, outputs):
-        outputs.out[0] = inputs.in_[3]
-        outputs.out[1] = inputs.in_[4]
-        outputs.out[2] = inputs.in_[5]
-    RShift3 = build(mkRShift3)
+    in_ = inputs.in_
+    load = inputs.load
+    address = inputs.address
 
-    shifted = RShift3(in_=inputs.address)
-    load = DMux8Way(in_=inputs.load, sel=shifted.out)
-    ram0 = RAM8(in_=inputs.in_, load=load.a, address=inputs.address)
-    ram1 = RAM8(in_=inputs.in_, load=load.b, address=inputs.address)
-    ram2 = RAM8(in_=inputs.in_, load=load.c, address=inputs.address)
-    ram3 = RAM8(in_=inputs.in_, load=load.d, address=inputs.address)
-    ram4 = RAM8(in_=inputs.in_, load=load.e, address=inputs.address)
-    ram5 = RAM8(in_=inputs.in_, load=load.f, address=inputs.address)
-    ram6 = RAM8(in_=inputs.in_, load=load.g, address=inputs.address)
-    ram7 = RAM8(in_=inputs.in_, load=load.h, address=inputs.address)
-    outputs.out = Mux8Way16(a=ram0.out, b=ram1.out, c=ram2.out, d=ram3.out,
-                            e=ram4.out, f=ram5.out, g=ram6.out, h=ram7.out,
-                            sel=shifted.out).out
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_03.RAM64(in_=in_, load=load, address=address)
+
+    outputs.out = n1.out
 
 RAM64 = build(mkRAM64)
 
 
 def mkRAM512(inputs, outputs):
-    pass
-    
-    # This is just too slow
-#     def mkRShift3(inputs, outputs):
-#         outputs.out[0] = inputs.in_[3]
-#         outputs.out[1] = inputs.in_[4]
-#         outputs.out[2] = inputs.in_[5]
-#         outputs.out[3] = inputs.in_[6]
-#         outputs.out[4] = inputs.in_[7]
-#         outputs.out[5] = inputs.in_[8]
-#     RShift3 = build(mkRShift3)
-#
-#     shifted = RShift3(in_=inputs.address)
-#     load = DMux8Way(in_=inputs.load, sel=shifted.out)
-#     ram0 = RAM64(in_=inputs.in_, load=load.a, address=inputs.address)
-#     ram1 = RAM64(in_=inputs.in_, load=load.b, address=inputs.address)
-#     ram2 = RAM64(in_=inputs.in_, load=load.c, address=inputs.address)
-#     ram3 = RAM64(in_=inputs.in_, load=load.d, address=inputs.address)
-#     ram4 = RAM64(in_=inputs.in_, load=load.e, address=inputs.address)
-#     ram5 = RAM64(in_=inputs.in_, load=load.f, address=inputs.address)
-#     ram6 = RAM64(in_=inputs.in_, load=load.g, address=inputs.address)
-#     ram7 = RAM64(in_=inputs.in_, load=load.h, address=inputs.address)
-#     outputs.out = Mux8Way16(a=ram0.out, b=ram1.out, c=ram2.out, d=ram3.out,
-#                             e=ram4.out, f=ram5.out, g=ram6.out, h=ram7.out,
-#                             sel=shifted.out).out
-#
-# RAM512 = build(mkRAM512)
+    in_ = inputs.in_
+    load = inputs.load
+    address = inputs.address
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_03.RAM512(in_=in_, load=load, address=address)
+
+    outputs.out = n1.out
+
+RAM512 = build(mkRAM512)
 
 
-# def mkRAM4K(inputs, outputs):
-#     pass
+# SOLVERS: This has gotten repetitive by now, so just use the provided RAM4K and RAM16K
+RAM4K = solved_03.RAM4K
+RAM16K = solved_03.RAM16K
 
-RAM16K = RAM(14)
-"""14 address bits yields a 16K memory."""
 
 def mkPC(inputs, outputs):
     in_ = inputs.in_
@@ -124,13 +99,9 @@ def mkPC(inputs, outputs):
     inc = inputs.inc
     reset = inputs.reset
     
-    reseted = lazy()
-    pc = Register(in_=reseted.out, load=1)
-    
-    inced = Mux16(a=pc.out, b=Inc16(in_=pc.out).out, sel=inc)
-    loaded = Mux16(a=inced.out, b=in_, sel=load)
-    reseted.set(Mux16(a=loaded.out, b=0, sel=reset))
-    
-    outputs.out = pc.out
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_03.PC(in_=in_, load=load, inc=inc, reset=reset)
+
+    outputs.out = n1.out
 
 PC = build(mkPC)

--- a/project_04.py
+++ b/project_04.py
@@ -1,0 +1,38 @@
+# See https://www.nand2tetris.org/project04
+
+# SOLVERS: remove this import to get started
+from nand.solutions import solved_04
+
+
+# SOLVERS: MULT_ASM and FILL_ASM should be a lists of strings, each one an assembly instruction.
+# 
+
+# Multiplies R0 and R1 and stores the result in R2.
+# (R0, R1, R2 refer to RAM[0], RAM[1], and RAM[2], respectively.)
+
+# MULT_ASM = """
+# // Here's where the magic happens:
+# (top)  
+#   @0
+# ...
+# """.split('\n')
+
+MULT_ASM = solved_04.MULT_ASM
+
+
+# Runs an infinite loop that listens to the keyboard input.
+# When a key is pressed (any key), the program blackens the screen,
+# i.e. writes "black" in every pixel;
+# the screen should remain fully black as long as the key is pressed. 
+# When no key is pressed, the program clears the screen, i.e. writes
+# "white" in every pixel;
+# the screen should remain fully clear as long as no key is pressed.
+
+# FILL_ASM = """
+# // Here's where the magic happens:
+# (top)  
+#   @0
+# ...
+# """.split('\n')
+
+FILL_ASM = solved_04.FILL_ASM

--- a/project_05.py
+++ b/project_05.py
@@ -1,3 +1,5 @@
+# See https://www.nand2tetris.org/project05
+
 from nand import RAM, ROM, Input, build, lazy
 from project_01 import *
 from project_02 import *

--- a/project_05.py
+++ b/project_05.py
@@ -3,38 +3,20 @@ from project_01 import *
 from project_02 import *
 from project_03 import *
 
+# SOLVERS: remove this import to get started
+from nand.solutions import solved_05
+
+
 def mkMemorySystem(inputs, outputs):
     in_ = inputs.in_
     load = inputs.load
     address = inputs.address
 
-    def mkShift13(inputs, outputs):
-        outputs.out[0] = inputs.in_[13]
-        outputs.out[1] = inputs.in_[14]
-    Shift13 = build(mkShift13)
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    # Hint: you'll need a RAM(14), a RAM(13), and an Input.
+    n1 = solved_05.MemorySystem(in_=in_, load=load, address=address)
 
-    def mkMask14(inputs, outputs):
-        for i in range(14):
-            outputs.out[i] = inputs.in_[i]
-    Mask14 = build(mkMask14)
-
-    bank = Shift13(in_=address).out
-    load_bank = DMux4Way(in_=load, sel=bank)
-    address14 = Mask14(in_=address).out
-
-    # addresses 0x0000 to 0x3FFF
-    ram = RAM(14)(in_=in_, load=Or(a=load_bank.a, b=load_bank.b).out, address=address14)
-
-    # addresses 0x4000 to 0x5FFFF
-    # TODO: connect to pygame display
-    # note: bit 13 is definitely zero, so address[0..13] == address[0..12]
-    screen = RAM(13)(in_=in_, load=load_bank.c, address=address14)
-
-    # address 0x6000
-    # TODO: keyboard = Keyboard()
-    keyboard = Input()
-
-    outputs.out = Mux4Way16(a=ram.out, b=ram.out, c=screen.out, d=keyboard.out, sel=bank).out
+    outputs.out = n1.out
 
 MemorySystem = build(mkMemorySystem)
 
@@ -46,29 +28,13 @@ def mkCPU(inputs, outputs):
                                      # program (reset==1) or continue executing
                                      # the current program (reset==0).
 
-    i, _, _, a, c5, c4, c3, c2, c1, c0, da, dd, dm, jlt, jeq, jgt = [instruction[j] for j in reversed(range(16))]
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_05.CPU(inM=inM, instruction=instruction, reset=reset)
 
-    not_i = Not(in_=i).out
-
-    alu = lazy()
-    a_reg = Register(in_=Mux16(a=instruction, b=alu.out, sel=i).out, load=Or(a=not_i, b=da).out)
-    d_reg = Register(in_=alu.out, load=And(a=i, b=dd).out)
-    jump = And(a=i,
-               b=Or(a=     And(a=alu.ng, b=jlt).out,                      # lt
-                    b=Or(a=And(a=alu.zr, b=jeq).out,                      # eq
-                         b=And(a=And(a=Not(in_=alu.ng).out, b=Not(in_=alu.zr).out).out, b=jgt).out  # gt
-                         ).out
-                    ).out
-              ).out
-    pc = PC(in_=a_reg.out, load=jump, inc=1, reset=reset)
-    alu.set(ALU(x=d_reg.out, y=Mux16(a=a_reg.out, b=inM, sel=a).out,
-                zx=c5, nx=c4, zy=c3, ny=c2, f=c1, no=c0))
-
-
-    outputs.outM = alu.out                   # M value output
-    outputs.writeM = And(a=dm, b=i).out      # Write to M?
-    outputs.addressM = a_reg.out             # Address in data memory (of M) (latched)
-    outputs.pc = pc.out                      # address of next instruction (latched)
+    outputs.outM = n1.outM           # M value output
+    outputs.writeM = n1.writeM       # Write to M?
+    outputs.addressM = n1.addressM   # Address in data memory (of M) (latched)
+    outputs.pc = n1.pc               # address of next instruction (latched)
 
 CPU = build(mkCPU)
 
@@ -76,16 +42,9 @@ CPU = build(mkCPU)
 def mkComputer(inputs, outputs):
     reset = inputs.reset
     
-    cpu = lazy()
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_05.Computer(reset=reset)
 
-    rom = ROM(15)(address=cpu.pc)
-
-    mem = MemorySystem(in_=cpu.outM, load=cpu.writeM, address=cpu.addressM)
-
-    cpu.set(CPU(inM=mem.out, instruction=rom.out, reset=reset))
-
-    # HACK: need some dependency to force the whole thing to be synthesized.
-    # Exposing the PC also makes it easy to observe what's happening in a dumb way.
-    outputs.pc = cpu.pc
+    outputs.pc = n1.pc
 
 Computer = build(mkComputer)

--- a/project_06.py
+++ b/project_06.py
@@ -1,138 +1,30 @@
-# Disclaimer: this implementation was written quickly and seems to work, but those are the only good
-# things that can be said about it.
-
-import re
-
-ALU_CONTROL = {
-    # These match the bit patterns used in Add and Max:
-    "0":   0b101010,
-    "A":   0b110000,
-    "D":   0b001100,
-    "D-A": 0b010011,
-    "D+A": 0b000010,
-    # These are confirmed to produce the correct results, but may not match where more than
-    # one equivalent exists:
-    "1":   0b111111,
-    "-1":  0b111010, # 0b101001,
-    "D&A": 0b000000,
-    "D|A": 0b010101,
-    "A-D": 0b000111,
-    "!D":  0b001011,
-    "!A":  0b110001, # 0b100011,
-    "D+1": 0b011111,
-    "A+1": 0b110111,
-    "D-1": 0b001110,
-    "A-1": 0b110010,
-    "-D":  0b001111,
-    "-A":  0b110011,
-}
-
-JMP_CONTROL = {
-    "LT": 0b100,
-    "LE": 0b110,
-    "EQ": 0b010,
-    "NE": 0b101,
-    "GE": 0b011,
-    "GT": 0b001,
-    "MP": 0b111,
-}
-
-BUILTIN_SYMBOLS = {
-    **{
-        "SP":       0,
-        "LCL":      1,
-        "ARG":      2,
-        "THIS":     3,
-        "THAT":     4,
-        "SCREEN":   0x4000,
-        "KEYBOARD": 0x6000,
-    },
-    **{ f"R{i}": i for i in range(16)}
-}
+# SOLVERS: remove this import to get started
+from nand.solutions import solved_06
 
 
 def parse_op(string):
     """Parse a single assembly op directly to the corresponding Hack instruction word.
-    
+
     The op may be a numeric symbol (an A-command) or a C-command, but not a reference
     to a symbol or variable.
     """
-    
-    m = re.match(r"@((?:0x)?\d+)", string)
-    if m:
-        return eval(m.group(1))
-    else:
-        m = re.match(r"(?:([ADM]+)=)?([^;]+)(?:;J(..))?", string)
-        if m:
-            dest_str = m.group(1) or ""
-            dest = 0
-            if 'A' in dest_str:
-                dest |= 0b100
-            if 'D' in dest_str:
-                dest |= 0b010
-            if 'M' in dest_str:
-                dest |= 0b001
-        
-            alu_str = m.group(2).replace('M', 'A')
-            if alu_str in ALU_CONTROL:
-                alu = ALU_CONTROL[alu_str]
-                m_for_a = int('M' in m.group(2))
-            else:
-                raise Exception(f"unrecognized alu op: {m.group(2)}")
-            
-            jmp_str = m.group(3)
-            if jmp_str is None:
-                jmp = 0
-            elif jmp_str in JMP_CONTROL:
-                jmp = JMP_CONTROL[jmp_str]
-            else:
-                raise Exception(f"unrecognized jump: J{m.group(3)}")
-        
-            return (0b111 << 13) | (m_for_a << 12) | (alu << 6) | (dest << 3) | jmp
-        else:
-            raise Exception(f"unrecognized: {line}")
+
+    # SOLVERS: replace this with code to parse a single assembly instruction string, producing
+    # a machine instruction as a 16-bit int
+    instr = solved_06.parse_op(string)
+
+    return instr
 
 
 def load_file(f):
     """Load the lines of file and parse them as assembly commands, accounting for
     builtin symbols, labels, and variables.
-    
+
     "//" denotes a comment and is ignored, along with the remainder of the line.
     Leading and trailing white space on each line is ignored.
     After comments and white space are stripped, blank lines are ignored.
     """
-    
-    code_lines = []
-    for line in f:
-        m = re.match(r"([^/]*)(?://.*)?", line)
-        if m:
-            string = m.group(1).strip()
-        else:
-            string = line.strip()
-        
-        if string:
-            code_lines.append(string)
-    
-    symbols = BUILTIN_SYMBOLS.copy()
-    loc = 0
-    for line in code_lines:
-        m = re.match(r"\((.*)\)", line)
-        if m:
-            symbols[m.group(1)] = loc
-        else:
-            loc += 1
-        
-    ops = []
-    next_variable = 16
-    for line in code_lines:
-        if "(" not in line:
-            m = re.match(r"@(\D.*)", line)
-            if m:
-                symbol_str = m.group(1)
-                if symbol_str not in symbols:
-                    symbols[symbol_str] = next_variable
-                    next_variable += 1
-                ops.append(symbols[symbol_str])
-            else:
-                ops.append(parse_op(line))
-    return ops
+
+    # SOLVERS: replace this with code to parse a sequence of lines, using parse_op 
+    # to handle the individual instructions found within it.
+    return solved_06.load_file(f)

--- a/project_06.py
+++ b/project_06.py
@@ -1,3 +1,5 @@
+# See https://www.nand2tetris.org/project06
+
 # SOLVERS: remove this import to get started
 from nand.solutions import solved_06
 

--- a/test_01.py
+++ b/test_01.py
@@ -1,3 +1,4 @@
+from nand import run, unsigned
 from project_01 import *
 
 def test_nand():

--- a/test_02.py
+++ b/test_02.py
@@ -1,3 +1,4 @@
+from nand import run, unsigned
 from project_02 import *
 
 def test_halfAdder():

--- a/test_03.py
+++ b/test_03.py
@@ -247,7 +247,7 @@ def test_ram512():
     ram_test(ram, 512)
 
 
-# This is still just too darn slow (more than a minute).
+# This is still just too darn slow (almost 5 minutes.)
 # def test_ram4k_legit():
 #     """The challenge is to implement RAM4K from Registers."""
 #     assert gate_count(RAM4K).keys() == set(['nands', 'dffs'])

--- a/test_03.py
+++ b/test_03.py
@@ -223,26 +223,45 @@ def test_ram8():
     ram = run(RAM8)
     ram_test(ram, 8)
 
+
+def test_ram64_legit():
+    """The challenge is to implement RAM64 from Registers."""
+    assert gate_count(RAM64).keys() == set(['nands', 'dffs'])
+
 def test_ram64():
-    # Gate-level simulation is anoyingly slow for this large chip, so use the less
+    # Gate-level simulation is annoyingly slow for this large chip, so use the less
     # exacting but much more efficient codegen simulator:
     ram = run(RAM64, simulator='codegen')
     ram_test(ram, 64)
-    assert False
 
-# This one's implementation is commented out:
-# def test_ram512():
-#     ram = run(RAM512)
-#     ram_test(ram, 512)
-#
-# This one I never even tried:
-# def test_ram4k():
-#     ram = run(RAM4K)
-#     ram_test(ram, 4096)
 
+def test_ram512_legit():
+    """The challenge is to implement RAM512 from Registers."""
+    assert gate_count(RAM512).keys() == set(['nands', 'dffs'])
+
+def test_ram512():
+    # Gate-level simulation is annoyingly slow for this large chip, so use the less
+    # exacting but much more efficient codegen simulator:
+    ram = run(RAM512, simulator='codegen')
+    ram_test(ram, 512)
+
+
+def test_ram4k_legit():
+    """The challenge is to implement RAM4K from Registers."""
+    assert gate_count(RAM4K).keys() == set(['nands', 'dffs'])
+
+def test_ram4k():
+    # Gate-level simulation is annoyingly slow for this large chip, so use the less
+    # exacting but much more efficient codegen simulator:
+    ram = run(RAM4K, simulator='codegen')
+    ram_test(ram, 4096)
+
+
+def test_ram16k_legit():
+    # This large RAM has to be implemented as a wrapper around a Memory:
+    assert True
 
 def test_ram16K():
-    # This large RAM has to be implemented as a wrapper around a Memory:
     ram = run(RAM16K)
     ram_test(ram, 16384)
 

--- a/test_03.py
+++ b/test_03.py
@@ -1,3 +1,4 @@
+from nand import DFF, run, gate_count
 from project_03 import *
 
 def dff_coarse_test(dff):

--- a/test_03.py
+++ b/test_03.py
@@ -223,11 +223,12 @@ def test_ram8():
     ram = run(RAM8)
     ram_test(ram, 8)
 
-
-# This one works, but it's annoyingly slow (~15s):
-# def test_ram64():
-#     ram = run(RAM64)
-#     ram_test(ram, 64)
+def test_ram64():
+    # Gate-level simulation is anoyingly slow for this large chip, so use the less
+    # exacting but much more efficient codegen simulator:
+    ram = run(RAM64, simulator='codegen')
+    ram_test(ram, 64)
+    assert False
 
 # This one's implementation is commented out:
 # def test_ram512():

--- a/test_03.py
+++ b/test_03.py
@@ -247,15 +247,16 @@ def test_ram512():
     ram_test(ram, 512)
 
 
-def test_ram4k_legit():
-    """The challenge is to implement RAM4K from Registers."""
-    assert gate_count(RAM4K).keys() == set(['nands', 'dffs'])
-
-def test_ram4k():
-    # Gate-level simulation is annoyingly slow for this large chip, so use the less
-    # exacting but much more efficient codegen simulator:
-    ram = run(RAM4K, simulator='codegen')
-    ram_test(ram, 4096)
+# This is still just too darn slow (more than a minute).
+# def test_ram4k_legit():
+#     """The challenge is to implement RAM4K from Registers."""
+#     assert gate_count(RAM4K).keys() == set(['nands', 'dffs'])
+#
+# def test_ram4k():
+#     # Gate-level simulation is annoyingly slow for this large chip, so use the less
+#     # exacting but much more efficient codegen simulator:
+#     ram = run(RAM4K, simulator='codegen')
+#     ram_test(ram, 4096)
 
 
 def test_ram16k_legit():

--- a/test_03.py
+++ b/test_03.py
@@ -65,7 +65,7 @@ def dff_fine_test(dff):
     # global), and providing tick() and tock() to cycle it.
 
 
-def test_dff_legit():
+def test_my_dff_legit():
     """The challenge is to implement DFF with only Nand gates."""
     assert list(gate_count(MyDFF).keys()) == ['nands']
 

--- a/test_04.py
+++ b/test_04.py
@@ -1,0 +1,81 @@
+from nand import run, unsigned
+# Note: using the included implementations, so you can work on the projects in any order
+from nand.solutions.solved_05 import Computer
+from nand.solutions.solved_06 import load_file
+
+from project_04 import *
+
+
+def test_mult():
+    computer = run(Computer)
+
+    computer.init_rom(load_file(MULT_ASM))
+
+    computer.poke(2, -1)
+    for _ in range(20):
+        computer.ticktock()
+    assert computer.peek(2) == 0
+
+    computer.poke(0, 1)
+    computer.poke(2, -1)
+    computer.reset_program()
+    for _ in range(50):
+        computer.ticktock()
+    assert computer.peek(2) == 0
+
+    computer.poke(0, 0)
+    computer.poke(1, 2)
+    computer.poke(2, -1)
+    computer.reset_program()
+    for _ in range(80):
+        computer.ticktock()
+    assert computer.peek(2) == 0
+
+    computer.poke(0, 3)
+    computer.poke(1, 1)
+    computer.poke(2, -1)
+    computer.reset_program()
+    for _ in range(120):
+        computer.ticktock()
+    assert computer.peek(2) == 3
+
+    computer.poke(0, 2)
+    computer.poke(1, 4)
+    computer.poke(2, -1)
+    computer.reset_program()
+    for _ in range(150):
+        computer.ticktock()
+    assert computer.peek(2) == 8
+
+    computer.poke(0, 6)
+    computer.poke(1, 7)
+    computer.poke(2, -1)
+    computer.reset_program()
+    for _ in range(210):
+        computer.ticktock()
+    assert computer.peek(2) == 42
+
+
+def test_fill():
+    # We're going to run a few million cycles, so the faster simulator is a better option:
+    computer = run(Computer, simulator='codegen')
+
+    computer.init_rom(load_file(FILL_ASM))
+
+    computer.set_keydown(0)  # the keyboard is untouched
+    for _ in range(1_000_000):
+        computer.ticktock()
+    for i in range(256*512//16):
+        assert unsigned(computer.peek_screen(i)) == 0x0000  # white
+
+    computer.set_keydown(1)  # a keyboard key is pressed
+    for _ in range(1_000_000):
+        computer.ticktock()
+    for i in range(256*512//16):
+        assert unsigned(computer.peek_screen(i)) == 0xffff  # black
+
+    computer.set_keydown(0)  # the keyboard is untouched
+    for _ in range(1_000_000):
+        computer.ticktock()
+    for i in range(256*512//16):
+        assert unsigned(computer.peek_screen(i)) == 0x0000  # white

--- a/test_05.py
+++ b/test_05.py
@@ -1,5 +1,6 @@
-from project_05 import *
+from nand import run
 import nand.component
+from project_05 import *
 
 
 def test_memory_system():

--- a/test_optimal_01.py
+++ b/test_optimal_01.py
@@ -2,6 +2,7 @@
 in using the minimum number of gates and/or making the (theoretically) fastest circuits.
 """
 
+from nand import gate_count
 from project_01 import *
 
 def test_nand():

--- a/test_optimal_02.py
+++ b/test_optimal_02.py
@@ -2,6 +2,7 @@
 in using the minimum number of gates and/or making the (theoretically) fastest circuits.
 """
 
+from nand import gate_count
 from project_02 import *
 
 def test_halfAdder():

--- a/test_optimal_03.py
+++ b/test_optimal_03.py
@@ -39,16 +39,17 @@ def test_ram64():
         'dffs': 1_024
     }
 
-# def test_ram512():
-#     assert gate_count(RAM512) == {
-#         'nands': 60_946,  # Uh oh.
-#         'flip_flops': 8_192
-#     }
-#
+def test_ram512():
+    assert gate_count(RAM512) == {
+        'nands': 59_778,  # ?
+        'dffs': 8_192
+    }
+
+# Even counting the gates on this guy is super slow (~40s), so skip it
 # def test_ram4k():
 #     assert gate_count(RAM4K) == {
-#         'nands': -1,  # ?
-#         'flip_flops': 65_536
+#         'nands': 478_594,  # ?
+#         'dffs': 65_536
 #     }
 
 def test_ram16k():

--- a/test_optimal_03.py
+++ b/test_optimal_03.py
@@ -2,6 +2,7 @@
 in using the minimum number of gates and/or making the (theoretically) fastest circuits.
 """
 
+from nand import DFF, gate_count
 from project_03 import *
 
 def test_dff():


### PR DESCRIPTION
This allows all the tests to run, and allows for working on solutions incrementally, while hiding the solutions away so any hypothetical solvers can work on them one at a time.

Also added some comments giving a little guidance about how to proceed.

It was weird that project 04 was missing, and now that an assembler and simulator are implemented, there's no reason not to include it.

Other enhancements:
- realized I could test RAM64 and RAM512 by using the faster simulator, so added that
- implemented a few more components in codegen that are used in RAMs: `DMux`, `DMux8Way`, `Mux8Way16`
- `SyntaxError`s for missing and unexpected arguments and outputs
- fixed a bug in the commented and never-tested RAM512 solution
- implemented and tested RAM4K, which is still too slow but no longer impossible to run
- fixed a hidden bug in codegen with `Register` references