### PR TITLE
Crank out another VM translator

### DIFF
--- a/alt/README.md
+++ b/alt/README.md
@@ -11,5 +11,6 @@ See each module for instructions.
 | Location       | Nands | ROM words for Pong | Cycles for Sys.init | Notes  |
 |----------------|------:|-------------------:|--------------------:|--------|
 | project_0*.py  | 1,250 |            29,500  |          4 million  | This is the standard design from nand2tetris, with a reasonably efficient VM translator. |
+| alt/lazy.py    | _1,250_ |          26,000  |        3.3 million  | A slighty cleverer translator for the standard CPU, which avoids updating the stack when that's easy to do. |
 | alt/sp.py      | 1,800 |            15,700  |        2.6 million  | Adds instructions for pushing/popping values to/from the stack, making programs more compact. |
 | alt/threaded.py| 1,550 |             8,700  |        5.1 million  | Adds lightweight CALL/RTN instructions, enabling a very compact "threaded interpreter" translation. |

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -125,7 +125,7 @@ class Translator(solved_07.Translator):
             self.asm.instr("M=D")
             self.top_in_d = False
         else:
-            solved_07.Translator.pop_pointer(index)
+            solved_07.Translator.pop_pointer(self, index)
 
     def push_pointer(self, index):
         self._fix_stack()

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -1,0 +1,43 @@
+"""A more efficient VM translator for the book's CPU.
+
+Uses a single trick: when an opcode is encountered, if the opcode pushes a value on to the stack, 
+the value is simply left in D and the translator remembers that this was done. If the next opcode
+consumes the top of the stack, it can usually generate a simpler sequence using the value from D.
+Otherwise, the value is pushed and then the usual opcodes are emitted.
+"""
+
+
+from nand.translate import AssemblySource
+from nand.solutions import solved_07
+
+
+class Translator(solved_07.Translator):
+    def __init__(self):
+        self.asm = AssemblySource()
+        
+        solved_07.Translator.__init__(self, self.asm)
+        
+        self.top_in_d = False
+    
+    def push_constant(self, value):
+        self._fix_stack()
+
+        self.asm.start(f"push constant {value}")
+        self.asm.instr(f"@{value}")
+        self.asm.instr(f"D=A")
+        self.top_in_d = True
+
+
+    def add(self):
+        if self.top_in_d:
+            self.asm.start(f"add")
+            self.asm.instr("@SP")
+            self.asm.instr("A=M-1")
+            self.asm.instr("M=D+M")
+        else:
+            solved_07.Translator.add(self)
+
+    def _fix_stack(self):
+        if self.top_in_d:
+            self._push_d()
+            self.top_in_d = False

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -137,6 +137,24 @@ class Translator(solved_07.Translator):
         self.top_in_d = True
 
 
+    def label(self, name):
+        self._fix_stack()
+        solved_07.Translator.label(self, name)
+
+    def if_goto(self, name):
+        if self.top_in_d:
+            self.asm.start(f"if-goto {name} (from D)")
+            self.asm.instr(f"@{self.function_namespace}${name}")
+            self.asm.instr("D;JNE")
+            self.top_in_d = False
+        else:
+            solved_07.Translator.if_goto(self, name)
+
+    def goto(self, name):
+        self._fix_stack()
+        solved_07.Translator.goto(self, name)
+
+
     def _fix_stack(self):
         if self.top_in_d:
             self._push_d()

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -120,12 +120,7 @@ class Translator(solved_07.Translator):
     def pop_pointer(self, index):
         if self.top_in_d:
             self.asm.start(f"pop pointer {index} (from D)")
-            if index == 0:
-                segment_ptr = "THIS"
-            elif index == 1:
-                segment_ptr = "THAT"
-            else:
-                raise SyntaxError(f"Invalid index for pop pointer: {index!r}")
+            segment_ptr = ("THIS", "THAT")[index]
             self.asm.instr(f"@{segment_ptr}")
             self.asm.instr("M=D")
             self.top_in_d = False
@@ -136,12 +131,7 @@ class Translator(solved_07.Translator):
         self._fix_stack()
         
         self.asm.start(f"push pointer {index}")
-        if index == 0:
-            segment_ptr = "THIS"
-        elif index == 1:
-            segment_ptr = "THAT"
-        else:
-            raise SyntaxError(f"Invalid index for push pointer: {index}")
+        segment_ptr = ("THIS", "THAT")[index]
         self.asm.instr(f"@{segment_ptr}")
         self.asm.instr("D=M")
         self.top_in_d = True

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -4,6 +4,9 @@ Uses a single trick: when an opcode is encountered, if the opcode pushes a value
 the value is simply left in D and the translator remembers that this was done. If the next opcode
 consumes the top of the stack, it can usually generate a simpler sequence using the value from D.
 Otherwise, the value is pushed and then the usual opcodes are emitted.
+
+Note on debugging: this tends to make tracing hard to interpret, because whenever a stack operation
+is omitted, the stack just looks wrong in the trace.
 """
 
 
@@ -18,7 +21,10 @@ class Translator(solved_07.Translator):
         solved_07.Translator.__init__(self, self.asm)
         
         self.top_in_d = False
-    
+
+    def finish(self):
+        self._fix_stack()
+
     def push_constant(self, value):
         self._fix_stack()
 
@@ -27,15 +33,36 @@ class Translator(solved_07.Translator):
         self.asm.instr(f"D=A")
         self.top_in_d = True
 
+    def lt(self):
+        self._fix_stack()
+        solved_07.Translator.lt(self)
 
-    def add(self):
+    def eq(self):
+        self._fix_stack()
+        solved_07.Translator.eq(self)
+
+    def gt(self):
+        self._fix_stack()
+        solved_07.Translator.gt(self)
+
+
+    def _binary(self, opcode, op):
         if self.top_in_d:
-            self.asm.start(f"add")
+            self.asm.start(opcode + " (from D)")
             self.asm.instr("@SP")
-            self.asm.instr("A=M-1")
-            self.asm.instr("M=D+M")
+            self.asm.instr("AM=M-1")
+            self.asm.instr(f"D={op}")
+            # Note: this isn't really a win if the next instruction is going to just push. 
         else:
-            solved_07.Translator.add(self)
+            solved_07.Translator._binary(self, opcode, op)
+
+    def _unary(self, opcode, op):
+        if self.top_in_d:
+            self.asm.start(opcode + " (from D)")
+            self.asm.instr(f"D={op.replace('M', 'D')}")
+            # Note: and it stays in D
+        else:
+            solved_07.Translator._unary(self, opcode, op)
 
     def _fix_stack(self):
         if self.top_in_d:

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -10,8 +10,8 @@ is omitted, the stack just looks wrong in the trace.
 """
 
 
-from nand.translate import AssemblySource
-from nand.solutions import solved_07
+from nand.translate import AssemblySource, translate_dir
+from nand.solutions import solved_05, solved_06, solved_07
 
 
 class Translator(solved_07.Translator):
@@ -141,3 +141,26 @@ class Translator(solved_07.Translator):
         if self.top_in_d:
             self._push_d()
             self.top_in_d = False
+
+
+
+if __name__ == "__main__":
+    TRACE = False
+
+    import sys
+    import computer
+
+    translate = Translator()
+    
+    translate.preamble()
+    
+    translate_dir(translate, solved_07.parse_line, sys.argv[1])
+    translate_dir(translate, solved_07.parse_line, "nand2tetris/tools/OS")  # HACK not committed
+    
+    if TRACE:
+        for instr in translate.asm:
+            print(instr)
+
+    computer.run(solved_06.assemble(translate.asm), chip=solved_05.Computer, src_map=translate.asm.src_map if TRACE else None)
+
+

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -116,6 +116,37 @@ class Translator(solved_07.Translator):
         self.asm.instr("D=M")
         self.top_in_d = True
 
+
+    def pop_pointer(self, index):
+        if self.top_in_d:
+            self.asm.start(f"pop pointer {index} (from D)")
+            if index == 0:
+                segment_ptr = "THIS"
+            elif index == 1:
+                segment_ptr = "THAT"
+            else:
+                raise SyntaxError(f"Invalid index for pop pointer: {index!r}")
+            self.asm.instr(f"@{segment_ptr}")
+            self.asm.instr("M=D")
+            self.top_in_d = False
+        else:
+            solved_07.Translator.pop_pointer(index)
+
+    def push_pointer(self, index):
+        self._fix_stack()
+        
+        self.asm.start(f"push pointer {index}")
+        if index == 0:
+            segment_ptr = "THIS"
+        elif index == 1:
+            segment_ptr = "THAT"
+        else:
+            raise SyntaxError(f"Invalid index for push pointer: {index}")
+        self.asm.instr(f"@{segment_ptr}")
+        self.asm.instr("D=M")
+        self.top_in_d = True
+
+
     def _fix_stack(self):
         if self.top_in_d:
             self._push_d()

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -155,6 +155,20 @@ class Translator(solved_07.Translator):
         solved_07.Translator.goto(self, name)
 
 
+    def function(self, class_name, function_name, num_vars):
+        assert not self.top_in_d
+        solved_07.Translator.function(self, class_name, function_name, num_vars)
+
+    def return_op(self):
+        # TODO: an alt. return handler?
+        self._fix_stack()
+        solved_07.Translator.return_op(self)
+
+    def call(self, class_name, function_name, num_args):
+        self._fix_stack()
+        solved_07.Translator.call(self, class_name, function_name, num_args)
+
+
     def _fix_stack(self):
         if self.top_in_d:
             self._push_d()

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -137,6 +137,24 @@ class Translator(solved_07.Translator):
         self.top_in_d = True
 
 
+    def pop_static(self, index):
+        if self.top_in_d:
+            self.asm.start(f"push static {index} (from D)")
+            self.asm.instr(f"@{self.class_namespace}.static{index}")
+            self.asm.instr("M=D")
+            self.top_in_d = False
+        else:
+            solved_07.Translator.pop_static(self, index)
+        
+    def push_static(self, index):
+        self._fix_stack()
+
+        self.asm.start(f"push static {index}")
+        self.asm.instr(f"@{self.class_namespace}.static{index}")
+        self.asm.instr("D=M")
+        self.top_in_d = True
+
+
     def label(self, name):
         self._fix_stack()
         solved_07.Translator.label(self, name)

--- a/alt/lazy.py
+++ b/alt/lazy.py
@@ -64,6 +64,58 @@ class Translator(solved_07.Translator):
         else:
             solved_07.Translator._unary(self, opcode, op)
 
+    def _pop_segment(self, segment_name, segment_ptr, index):
+        # TODO: pull it from D for small args for sure
+        # also for non-small by stashing D in R13?
+        self._fix_stack()
+        solved_07.Translator._pop_segment(self, segment_name, segment_ptr, index)
+
+    def pop_temp(self, index):
+        assert 0 <= index < 8
+        if not self.top_in_d:  # Beautiful: only this conditional is added
+            self.asm.start(f"pop temp {index}")
+            self._pop_d()
+        else:
+            self.asm.start(f"pop temp {index} (from D)")
+            self.top_in_d = False            
+        self.asm.instr(f"@R{5+index}")
+        self.asm.instr("M=D")
+
+    def _push_segment(self, segment_name, segment_ptr, index):
+        self._fix_stack()
+
+        self.asm.start(f"push {segment_name} {index}")
+        if index == 0:
+            self.asm.instr(f"@{segment_ptr}")
+            self.asm.instr("A=M")
+            self.asm.instr("D=M")
+        elif index == 1:
+            self.asm.instr(f"@{segment_ptr}")
+            self.asm.instr("A=M+1")
+            self.asm.instr("D=M")
+        elif index == 2:
+            self.asm.instr(f"@{segment_ptr}")
+            self.asm.instr("A=M+1")
+            self.asm.instr("A=A+1")
+            self.asm.instr("D=M")
+        else:
+            self.asm.instr(f"@{index}")
+            self.asm.instr("D=A")
+            self.asm.instr(f"@{segment_ptr}")
+            self.asm.instr("A=D+M")
+            self.asm.instr("D=M")
+        self.top_in_d = True
+ 
+    def push_temp(self, index):
+        assert 0 <= index < 8
+
+        self._fix_stack()
+
+        self.asm.start(f"push temp {index}")
+        self.asm.instr(f"@R{5+index}")
+        self.asm.instr("D=M")
+        self.top_in_d = True
+
     def _fix_stack(self):
         if self.top_in_d:
             self._push_d()

--- a/alt/sp.py
+++ b/alt/sp.py
@@ -265,7 +265,7 @@ class Translator(solved_07.Translator):
         self.asm.instr("A=--SP")
         self.asm.instr(f"SP++={op.replace('M', 'A')}")
 
-    def _unary(self, op):
+    def _unary(self, opcode, op):
         self.asm.start(opcode)
         self.asm.instr("D=--SP")
         self.asm.instr(f"SP++={op.replace('M', 'D')}")

--- a/alt/sp.py
+++ b/alt/sp.py
@@ -234,7 +234,8 @@ class Translator(solved_07.Translator):
             self.asm.instr(f"@{value}")
             self.asm.instr(f"SP++=A")
 
-    def _pop_segment(self, segment_ptr, index):
+    def _pop_segment(self, segment_name, segment_ptr, index):
+        self.asm.start(f"pop {segment_name} {index}")
         # Since pop doesn't overwrite A, a much simpler sequence works:
         if index == 0:
             self.asm.instr(f"@{segment_ptr}")
@@ -258,12 +259,14 @@ class Translator(solved_07.Translator):
         # TODO: no need for this as soon as everything's switched to use SP++ directly?
         self.asm.instr("D=--SP")
 
-    def _binary(self, op):
+    def _binary(self, opcode, op):
+        self.asm.start(opcode)
         self.asm.instr("D=--SP")
         self.asm.instr("A=--SP")
         self.asm.instr(f"SP++={op.replace('M', 'A')}")
 
     def _unary(self, op):
+        self.asm.start(opcode)
         self.asm.instr("D=--SP")
         self.asm.instr(f"SP++={op.replace('M', 'D')}")
 
@@ -377,6 +380,10 @@ class Translator(solved_07.Translator):
 
 
     # TODO: improve the common sequence for `return`.
+
+
+    def finish(self):
+        pass
 
 
 if __name__ == "__main__":

--- a/alt/test_lazy.py
+++ b/alt/test_lazy.py
@@ -46,17 +46,17 @@ def test_vm_statics_multiple_files():
     test_08.test_statics_multiple_files(translator=Translator)
 
 
-# @pytest.mark.skip(reason="Sources aren't in the repo yet")
+@pytest.mark.skip(reason="Sources aren't in the repo yet")
 def test_vm_pong_instructions():
     instruction_count = test_optimal_08.count_pong_instructions(Translator)
     
     # compare to the project_08 solution (about 28k)
-    assert instruction_count < -1  # 15_749
+    assert instruction_count == 25_929
 
 
 @pytest.mark.skip(reason="Sources aren't in the repo yet")
 def test_vm_cycles_to_init():
-    cycles = test_optimal_08.count_cycles_to_init(solved_05.Computer, assemble, Translator)
+    cycles = test_optimal_08.count_cycles_to_init(solved_05.Computer, solved_06.assemble, Translator)
 
     # compare to the project_08 solution (about 4m)
-    assert cycles < -1  # 2_612_707
+    assert cycles == 3_255_166

--- a/alt/test_lazy.py
+++ b/alt/test_lazy.py
@@ -1,0 +1,62 @@
+import pytest
+
+import test_07
+import test_08
+import test_optimal_08
+
+from alt.lazy import *
+
+
+#
+# VM translator:
+#
+
+def test_vm_simple_add():
+    test_07.test_simple_add(translator=Translator)
+
+def test_vm_stack_ops():
+    test_07.test_stack_ops(translator=Translator)
+
+def test_vm_memory_access_basic():
+    test_07.test_memory_access_basic(translator=Translator)
+
+def test_vm_memory_access_pointer():
+    test_07.test_memory_access_pointer(translator=Translator)
+
+def test_vm_memory_access_static():
+    test_07.test_memory_access_static(translator=Translator)
+
+
+def test_vm_basic_loop():
+    test_08.test_basic_loop(translator=Translator)
+
+def test_vm_fibonacci_series():
+    test_08.test_fibonacci_series(translator=Translator)
+    
+def test_vm_simple_function():
+    test_08.test_simple_function(translator=Translator)
+    
+def test_vm_nested_call():
+    test_08.test_nested_call(translator=Translator)
+
+def test_vm_fibonacci_element():
+    test_08.test_fibonacci_element(translator=Translator)
+
+def test_vm_statics_multiple_files():
+    test_08.test_statics_multiple_files(translator=Translator)
+
+
+# @pytest.mark.skip(reason="Sources aren't in the repo yet")
+def test_vm_pong_instructions():
+    instruction_count = test_optimal_08.count_pong_instructions(Translator)
+    
+    # compare to the project_08 solution (about 28k)
+    assert instruction_count < -1  # 15_749
+
+
+@pytest.mark.skip(reason="Sources aren't in the repo yet")
+def test_vm_cycles_to_init():
+    cycles = test_optimal_08.count_cycles_to_init(solved_05.Computer, assemble, Translator)
+
+    # compare to the project_08 solution (about 4m)
+    assert cycles < -1  # 2_612_707

--- a/alt/threaded.py
+++ b/alt/threaded.py
@@ -905,8 +905,7 @@ if __name__ == "__main__":
     translate_dir(translate, solved_07.parse_line, sys.argv[1])
     translate_dir(translate, solved_07.parse_line, "nand2tetris/tools/OS")  # HACK not committed
     
-    # if TRACE:
-    if True:
+    if TRACE:
         for instr in translate.asm:
             print(instr)
 

--- a/alt/threaded.py
+++ b/alt/threaded.py
@@ -888,6 +888,10 @@ class Translator:
         self.asm.instr("RTN")
 
 
+    def finish(self):
+        pass
+
+
 if __name__ == "__main__":
     TRACE = False
 

--- a/nand/solutions/solved_07.py
+++ b/nand/solutions/solved_07.py
@@ -195,24 +195,14 @@ class Translator:
 
     def pop_pointer(self, index):
         self.asm.start(f"pop pointer {index}")
-        if index == 0:
-            segment_ptr = "THIS"
-        elif index == 1:
-            segment_ptr = "THAT"
-        else:
-            raise SyntaxError(f"Invalid index for pop pointer: {index!r}")
+        segment_ptr = ("THIS", "THAT")[index]
         self._pop_d()
         self.asm.instr(f"@{segment_ptr}")
         self.asm.instr("M=D")
 
     def push_pointer(self, index):
         self.asm.start(f"push pointer {index}")
-        if index == 0:
-            segment_ptr = "THIS"
-        elif index == 1:
-            segment_ptr = "THAT"
-        else:
-            raise SyntaxError(f"Invalid index for push pointer: {index}")
+        segment_ptr = ("THIS", "THAT")[index]
         self.asm.instr(f"@{segment_ptr}")
         self.asm.instr("D=M")
         self._push_d()

--- a/nand/solutions/solved_07.py
+++ b/nand/solutions/solved_07.py
@@ -209,13 +209,13 @@ class Translator:
 
 
     def pop_static(self, index):
-        self.asm.start(f"push static {index}")
+        self.asm.start(f"pop static {index}")
         self._pop_d()
         self.asm.instr(f"@{self.class_namespace}.static{index}")
         self.asm.instr("M=D")
         
     def push_static(self, index):
-        self.asm.start(f"pop static {index}")
+        self.asm.start(f"push static {index}")
         self.asm.instr(f"@{self.class_namespace}.static{index}")
         self.asm.instr("D=M")
         self._push_d()

--- a/nand/solutions/solved_07.py
+++ b/nand/solutions/solved_07.py
@@ -105,20 +105,16 @@ class Translator:
         self.asm.label(return_label)
             
     def pop_local(self, index):
-        self.asm.start(f"pop local {index}")
-        self._pop_segment("LCL", index)
+        self._pop_segment("local", "LCL", index)
         
     def pop_argument(self, index):
-        self.asm.start(f"pop argument {index}")
-        self._pop_segment("ARG", index)
+        self._pop_segment("argument", "ARG", index)
         
     def pop_this(self, index):
-        self.asm.start(f"pop this {index}")
-        self._pop_segment("THIS", index)
+        self._pop_segment("this", "THIS", index)
         
     def pop_that(self, index):
-        self.asm.start(f"pop that {index}")
-        self._pop_segment("THAT", index)
+        self._pop_segment("that", "THAT", index)
     
     def pop_temp(self, index):
         assert 0 <= index < 8
@@ -127,7 +123,8 @@ class Translator:
         self.asm.instr(f"@R{5+index}")
         self.asm.instr("M=D")
     
-    def _pop_segment(self, segment_ptr, index):
+    def _pop_segment(self, segment_name, segment_ptr, index):
+        self.asm.start(f"pop {segment_name} {index}")
         if index <= 6:
             self._pop_d()
             
@@ -153,30 +150,19 @@ class Translator:
             self.asm.instr("M=D")
 
     def push_local(self, index):
-        self.asm.start(f"push local {index}")
-        return self._push_segment("LCL", index)
+        return self._push_segment("local", "LCL", index)
 
     def push_argument(self, index):
-        self.asm.start(f"push argument {index}")
-        return self._push_segment("ARG", index)
+        return self._push_segment("argument", "ARG", index)
 
     def push_this(self, index):
-        self.asm.start(f"push this {index}")
-        return self._push_segment("THIS", index)
+        return self._push_segment("this", "THIS", index)
 
     def push_that(self, index):
-        self.asm.start(f"push that {index}")
-        return self._push_segment("THAT", index)
+        return self._push_segment("that", "THAT", index)
 
-    def push_temp(self, index):
-        assert 0 <= index < 8
-        self.asm.start(f"push temp {index}")
-        self.asm.instr(f"@R{5+index}")
-        self.asm.instr("D=M")
-        self._push_d()
-        
-
-    def _push_segment(self, segment_ptr, index):
+    def _push_segment(self, segment_name, segment_ptr, index):
+        self.asm.start(f"push {segment_name} {index}")
         if index == 0:
             self.asm.instr(f"@{segment_ptr}")
             self.asm.instr("A=M")
@@ -198,6 +184,14 @@ class Translator:
             self.asm.instr("D=M")
         self._push_d()
 
+
+    def push_temp(self, index):
+        assert 0 <= index < 8
+        self.asm.start(f"push temp {index}")
+        self.asm.instr(f"@R{5+index}")
+        self.asm.instr("D=M")
+        self._push_d()
+        
 
     def pop_pointer(self, index):
         self.asm.start(f"pop pointer {index}")

--- a/nand/translate.py
+++ b/nand/translate.py
@@ -118,4 +118,5 @@ def translate_dir(translator, parse_line, dir_path):
             better_ops = translator.rewrite_ops(ops)
             for op, args in better_ops:
                 translator.__getattribute__(op)(*args)
+    translator.finish()
 

--- a/project_07.py
+++ b/project_07.py
@@ -148,6 +148,14 @@ class Translator:
 
     
     #
+    # (Optional) Cleanup:
+    #
+    def finish(self):
+        """Called after all opcodes are processed, in case the translator needs to say any last words."""
+        pass
+
+
+    #
     # (Optional) Optimization:
     #
     def rewrite_ops(self, ops):

--- a/test_07.py
+++ b/test_07.py
@@ -143,6 +143,10 @@ def test_memory_access_basic(chip=project_05.Computer, assemble=project_06.assem
     computer.poke(4, 3010)  # base address of the that segment
 
     translate.asm.run(assemble, computer, debug=True)
+    
+    # Note for debugging: this tests puts the stack in a funky state. LCL and ARG are _above_ SP, 
+    # which actually makes no sense and as a result the trace is confusing.
+    # For sensible tracing, use ARG = 247 nd LCL = 255
 
     assert computer.peek(256) == 472
     assert computer.peek(300) == 10

--- a/test_07.py
+++ b/test_07.py
@@ -17,6 +17,8 @@ def test_simple_add(chip=project_05.Computer, assemble=project_06.assemble, tran
     translate.push_constant(8)
     translate.add()
 
+    translate.finish()
+
     computer = run(chip, simulator='codegen')
     init_sp(computer)
 
@@ -79,6 +81,8 @@ def test_stack_ops(chip=project_05.Computer, assemble=project_06.assemble, trans
     translate.or_op()
     translate.not_op()
 
+    translate.finish()
+
     computer = run(chip, simulator='codegen')
 
     init_sp(computer)
@@ -128,6 +132,8 @@ def test_memory_access_basic(chip=project_05.Computer, assemble=project_06.assem
     translate.push_temp(6)
     translate.add()
 
+    translate.finish()
+
     computer = run(chip, simulator='codegen')
 
     init_sp(computer)
@@ -168,6 +174,8 @@ def test_memory_access_pointer(chip=project_05.Computer, assemble=project_06.ass
     translate.sub()
     translate.push_that(6)
     translate.add()
+
+    translate.finish()
     
     computer = run(chip, simulator='codegen')
 
@@ -197,6 +205,8 @@ def test_memory_access_static(chip=project_05.Computer, assemble=project_06.asse
     translate.sub()
     translate.push_static(8)
     translate.add()
+
+    translate.finish()
 
     computer = run(chip, simulator='codegen')
 

--- a/test_08.py
+++ b/test_08.py
@@ -32,6 +32,8 @@ def test_basic_loop(chip=project_05.Computer, assemble=project_06.assemble, tran
     translate.if_goto("LOOP_START")  # If counter > 0, goto LOOP_START
     translate.push_local(0)
 
+    translate.finish()
+
     computer = run(chip, simulator='codegen')
 
     test_07.init_sp(computer)
@@ -92,6 +94,8 @@ def test_fibonacci_series(chip=project_05.Computer, assemble=project_06.assemble
     
     translate.label("END_PROGRAM")
 
+    translate.finish()
+
     computer = run(chip, simulator='codegen')
 
     test_07.init_sp(computer)
@@ -124,6 +128,8 @@ def test_simple_function(chip=project_05.Computer, assemble=project_06.assemble,
     translate.push_argument(1)
     translate.sub()
     translate.return_op()
+
+    translate.finish()
 
     computer = run(chip, simulator='codegen')
 
@@ -219,6 +225,8 @@ def test_nested_call(chip=project_05.Computer, assemble=project_06.assemble, tra
     translate.add()
     translate.return_op()
 
+    translate.finish()
+
 
     computer = run(chip, simulator='codegen')
 
@@ -297,6 +305,8 @@ def test_fibonacci_element(chip=project_05.Computer, assemble=project_06.assembl
     translate.label("WHILE")
     translate.goto("WHILE")                  # loops infinitely
 
+    translate.finish()
+
 
     computer = run(chip, simulator='codegen')
 
@@ -351,6 +361,8 @@ def test_statics_multiple_files(chip=project_05.Computer, assemble=project_06.as
         translate.push_static(1)
         translate.sub()
         translate.return_op()
+
+    translate.finish()
 
 
     computer = run(chip, simulator='codegen')


### PR DESCRIPTION
Demonstrates what it takes to try a simple idea in a (mostly) new translator.

Re-uses much of the existing translator, but replaces some opcode handlers and injects a little bit of code into others.

This turned out to be good for about 10% on both code size and cycles, without requiring any analysis or significant debugging. It actually generates slightly worse code in some cases, though, and anyway it's clear that bigger wins are possible by looking at more than one opcode at a time.