### PR TITLE
Finally, a smaller CPU

### DIFF
--- a/alt/README.md
+++ b/alt/README.md
@@ -8,13 +8,14 @@ See each module for instructions.
 
 
 
-| Location       | Nands | ROM size       | Cycles per frame   | Cycles for init    | Notes  |
-|----------------|------:|---------------:|-------------------:|-------------------:|--------|
-| project_0*.py  | 1,262 |         28,300 |             34,415 |         4 million  | This is the standard design from nand2tetris, with a reasonably efficient VM translator. |
-| alt/lazy.py    | _same_ |  26,300 (-9%) |      29,245 (-15%) | 3.2 million (-15%) | A slighty cleverer translator for the standard CPU, which avoids updating the stack when that's easy to do. |
-| alt/sp.py      | 1,800 |  15,700 (-44%) |      21,877 (-36%) | 2.5 million (-18%) | Adds instructions for pushing/popping values to/from the stack, making programs more compact. |
-| alt/threaded.py| 1,550 |   8,700 (-69%) |      43,336 (+26%) | 5.1 million (+29%) | Adds lightweight CALL/RTN instructions, enabling a very compact "threaded interpreter" translation. |
-| alt/shift.py   | 1,300 | 28,300 (-0.1%) |      16,735 (-51%) | 3.5 million (-11%) | Adds a "shiftr" instruction, and rewrites "push constant 16; call Math.divide" to use it instead; also a more efficient Math.multiply using shiftr. |
+| Location       | Nands        | ROM size       | Cycles per frame | Cycles for init    | Notes  |
+|----------------|-------------:|---------------:|-----------------:|-------------------:|--------|
+| project_0*.py  | 1,262        |         28,300 |           34,415 |         4 million  | This is the standard design from nand2tetris, with a reasonably efficient VM translator. |
+| alt/lazy.py    | _same_       |   26,300 (-9%) |    29,245 (-15%) | 3.2 million (-15%) | A slighty cleverer translator for the standard CPU, which avoids updating the stack when that's easy to do. |
+| alt/sp.py      | 1,844 (+46%) |  15,700 (-44%) |    21,877 (-36%) | 2.5 million (-18%) | Adds instructions for pushing/popping values to/from the stack, making programs more compact. |
+| alt/threaded.py| 1,549 (+23%) |   8,700 (-69%) |    43,336 (+26%) | 5.1 million (+29%) | Adds lightweight CALL/RTN instructions, enabling a very compact "threaded interpreter" translation. |
+| alt/shift.py   | 1,311 (+4%)  | 28,300 (-0.1%) |    16,735 (-51%) | 3.5 million (-11%) | Adds a "shiftr" instruction, and rewrites "push constant 16; call Math.divide" to use it instead; also a more efficient Math.multiply using shiftr. |
+| alt/eight.py   | 1,032 (-18%) | _same_         |           +100%  |              +100% | Finally, a _smaller_ CPU, by using an 8-bit ALU and 2 cycles per instruction. |
 
 *ROM Size* is the total number of instructions in ROM when Pong is translated from the same VM 
 sources.

--- a/alt/compare.py
+++ b/alt/compare.py
@@ -12,7 +12,7 @@ def main():
         project_05.Computer, project_06.assemble, project_08.Translator)
     print_result("project_08.py", std)
 
-    print_relative_result("alt/eight.py", std, measure(alt.eight.EightComputer, project_06.assemble, project_08.Translator))
+    print_relative_result("alt/eight.py", std, (gate_count(alt.eight.EightComputer)['nands'], std[1], std[2]*2, std[3]*2))  # Cheeky    
     print_relative_result("alt/shift.py", std, measure(alt.shift.ShiftComputer, alt.shift.assemble, alt.shift.Translator))
     print_relative_result("alt/lazy.py", std, measure(project_05.Computer, project_06.assemble, alt.lazy.Translator))
     print_relative_result("alt/sp.py", std, measure(alt.sp.SPComputer, alt.sp.assemble, alt.sp.Translator))

--- a/alt/compare.py
+++ b/alt/compare.py
@@ -1,6 +1,7 @@
 from nand import gate_count
 import project_05, project_06, project_08
 import test_optimal_08
+import alt.eight
 import alt.lazy
 import alt.shift
 import alt.sp
@@ -11,6 +12,7 @@ def main():
         project_05.Computer, project_06.assemble, project_08.Translator)
     print_result("project_08.py", std)
 
+    print_relative_result("alt/eight.py", std, measure(alt.eight.EightComputer, project_06.assemble, project_08.Translator))
     print_relative_result("alt/shift.py", std, measure(alt.shift.ShiftComputer, alt.shift.assemble, alt.shift.Translator))
     print_relative_result("alt/lazy.py", std, measure(project_05.Computer, project_06.assemble, alt.lazy.Translator))
     print_relative_result("alt/sp.py", std, measure(alt.sp.SPComputer, alt.sp.assemble, alt.sp.Translator))

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -281,9 +281,7 @@ def mkEightCPU(inputs, outputs):
     jump_eq = And_(Not_(not_alu_both_zr), jeq)
     jump_gt = And_(Not_(alu.ng), not_alu_both_zr, jgt)
     jump = And_(i, Or_(jump_lt, jump_eq, jump_gt))
-    # pc = PC8(top_half=top_half, bottom_half=bottom_half, in_=a_both_reg, load=jump, reset=reset)
-    # TODO: get the split-cycle PC to do jumps
-    pc = PC(in_=a_both_reg, load=And_(bottom_half, jump), reset=reset, inc=bottom_half)
+    pc = PC8(top_half=top_half, bottom_half=bottom_half, in_=a_both_reg, load=And_(bottom_half, jump), reset=reset)
 
     y_parts = Split(in_=Mux16(a=a_both_reg, b=inM, sel=a).out)
     alu.set(EightALU(x=Mux8(a=d_lo_reg.out, b=d_hi_reg.out, sel=bottom_half).out,

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -130,6 +130,7 @@ def mkEightALU(inputs, outputs):
     
     # Note: need one more output to track overflow from the low half-word.
     outputs.carry_out = And(a=f, b=added.carry_out).out
+    outputs.carry_out = added.carry_out
 
 EightALU = build(mkEightALU)
 

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -189,7 +189,7 @@ def mkPC8(inputs, outputs):
 
     pc_lo_next = Register8(in_=reseted.out, load=top_half)
     # Note: want reset to happen immediately, but this way probably means some duplication
-    pc_lo = Register8(in_=Mux8(a=pc_lo_next.out, b=0, sel=reset).out, load=Or_(bottom_half, reset))
+    pc_lo = Register8(in_=Mux8(a=Mux8(a=pc_lo_next.out, b=in_lo, sel=load).out, b=0, sel=reset).out, load=Or_(bottom_half, reset, load))
     pc_hi = Register8(in_=reseted.out, load=bottom_half)
 
     # Clever? Can tell if overflow happened by inspecting the high bits of the old and new low words.

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -310,12 +310,6 @@ def mkEightCPU(inputs, outputs):
     outputs.writeM = And_(dm, i, bottom_half)                # Write to M?
     outputs.addressM = a_both_reg                            # Address in data memory (of M) (latched)
     outputs.pc = pc.out                                      # address of next instruction (latched)
-    
-    # HACK:
-    outputs.top_half = top_half
-    outputs.bottom_half = bottom_half
-    outputs.i = i
-    outputs.dm = dm
 
 EightCPU = build(mkEightCPU)
 

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -20,6 +20,13 @@ Note: this implementation defines _only_ a new CPU/Computer, which implements ex
 instruction set as the standard Hack CPU, so the same assembler and VM translator can be used. 
 The only way to tell them apart from the outside is to notice that each cycle makes half as 
 much progress.
+
+Note: some instructions _could_ be completed in a single cycle:
+- @xxx: about 30% of instructions (so, 15% savings), and decoding is simple
+- [A][D][M]=A|D|M (any time the ALU isn't actually needed): also almost 30%, but harder to 
+    decode (need a PLA)
+But this would almost certainly add some gates, so for now just focus on keeping it small and 
+don't worry about speed.
 """
 
 import re

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -188,7 +188,8 @@ def mkPC8(inputs, outputs):
     reseted = lazy()
 
     pc_lo_next = Register8(in_=reseted.out, load=top_half)
-    pc_lo = Register8(in_=Mux8(a=pc_lo_next.out, b=0, sel=reset).out, load=Or_(bottom_half, reset))  # Note: want reset to happen immediately, but this way probably means some duplication
+    # Note: want reset to happen immediately, but this way probably means some duplication
+    pc_lo = Register8(in_=Mux8(a=pc_lo_next.out, b=0, sel=reset).out, load=Or_(bottom_half, reset))
     pc_hi = Register8(in_=reseted.out, load=bottom_half)
 
     # Clever? Can tell if overflow happened by inspecting the high bits of the old and new low words.

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -1,0 +1,235 @@
+"""An attempt at a _smaller_ CPU, by reducing the ALU and data paths to only 8 bits, and taking 
+two cycles for every instruction. This is the classic "low-cost" CPU move (examples include the 
+Motorola 68000), promising compatibility with fancier architectures, and then delivering 
+seriously compromised performance, or conversely, locking users into an architecture so they can
+later be upsold to more expensive models.
+
+To that end, 8-bit versions of all the components are defined, plus components to pack/unpack 
+them into 16-bit values for communication with the ROM and memory (which are shared with the 
+normal chip.) Some of the 8-bit components have additional inputs and outputs to allow for 
+propagating carry bits from one word the the next.
+"""
+
+import re
+
+from nand import *
+from nand.translate import AssemblySource, translate_dir
+
+from nand.solutions.solved_01 import And, Or, Not, Xor
+from nand.solutions.solved_02 import HalfAdder, FullAdder
+from nand.solutions.solved_03 import Bit
+from nand.solutions.solved_05 import MemorySystem
+from nand.solutions import solved_06
+from nand.solutions import solved_07
+
+
+# Project 01:
+
+def mkNot8(inputs, outputs):
+    in_ = inputs.in_
+    for i in range(8):
+        outputs.out[i] = Not(in_=in_[i]).out
+
+Not8 = build(mkNot8)
+        
+
+def mkAnd8(inputs, outputs):
+    for i in range(8):
+        outputs.out[i] = And(a=inputs.a[i], b=inputs.b[i]).out
+
+And8 = build(mkAnd8)
+
+
+def mkMux8(inputs, outputs):
+    not_sel = Not(in_=inputs.sel).out
+    for i in range(8):
+        fromAneg = Nand(a=inputs.a[i], b=not_sel).out
+        fromBneg = Nand(a=inputs.b[i], b=inputs.sel).out
+        outputs.out[i] = Nand(a=fromAneg, b=fromBneg).out
+
+Mux8 = build(mkMux8)
+
+
+# Project 02:
+
+def mkInc8(inputs, outputs):
+    """Note: this is subtly different than Inc16 in that it may or may not actually increment
+    the value, under the control of carry_in. This allows the carry to propagate from the low 
+    word to the high word.
+    """
+    carry = inputs.carry_in
+    for i in range(8):
+        tmp = HalfAdder(a=carry, b=inputs.in_[i])
+        outputs.out[i] = tmp.sum
+        carry = tmp.carry
+    outputs.carry_out = carry
+
+Inc8 = build(mkInc8)
+
+
+def mkAdd8(inputs, outputs):
+    carry = inputs.carry_in
+    for i in range(8):
+        tmp = FullAdder(a=inputs.a[i], b=inputs.b[i], c=carry)
+        outputs.out[i] = tmp.sum
+        carry = tmp.carry
+    outputs.carry_out = carry
+
+Add8 = build(mkAdd8)
+
+
+def mkZero8(inputs, outputs):
+    in_ = inputs.in_
+    outputs.out = And(
+        a=And(a=And(a=Not(in_=in_[ 7]).out,
+                    b=Not(in_=in_[ 6]).out).out,
+              b=And(a=Not(in_=in_[ 5]).out,
+                    b=Not(in_=in_[ 4]).out).out).out,
+        b=And(a=And(a=Not(in_=in_[ 3]).out,
+                    b=Not(in_=in_[ 2]).out).out,
+              b=And(a=Not(in_=in_[ 1]).out,
+                    b=Not(in_=in_[ 0]).out).out).out).out
+Zero8 = build(mkZero8)
+
+
+def mkNeg8(inputs, outputs):
+    outputs.out = inputs.in_[7]
+
+Neg8 = build(mkNeg8)
+
+
+def mkEightALU(inputs, outputs):
+    x = inputs.x
+    y = inputs.y
+    carry_in = inputs.carry_in
+    
+    zx = inputs.zx
+    nx = inputs.nx
+    zy = inputs.zy
+    ny = inputs.ny
+    f  = inputs.f
+    no = inputs.no
+    
+    x_zeroed = Mux8(a=x, b=0, sel=zx).out
+    y_zeroed = Mux8(a=y, b=0, sel=zy).out
+
+    x_inverted = Mux8(a=x_zeroed, b=Not8(in_=x_zeroed).out, sel=nx).out
+    y_inverted = Mux8(a=y_zeroed, b=Not8(in_=y_zeroed).out, sel=ny).out
+    
+    anded = And8(a=x_inverted, b=y_inverted)
+    added = Add8(a=x_inverted, b=y_inverted, carry_in=carry_in)
+    
+    result = Mux8(a=anded.out, b=added.out, sel=f).out
+    result_inverted = Not8(in_=result).out
+    
+    out = Mux8(a=result, b=result_inverted, sel=no).out
+    
+    outputs.out = out
+    outputs.zr = Zero8(in_=out).out
+    outputs.ng = Neg8(in_=out).out
+    
+    # Note: need one more output to track overflow from the low half-word.
+    outputs.carry_out = And(a=f, b=added.carry_out).out
+
+EightALU = build(mkEightALU)
+
+
+# Project 03:
+
+def mkRegister8(inputs, outputs):
+    for i in range(8):
+        outputs.out[i] = Bit(in_=inputs.in_[i], load=inputs.load).out
+
+Register8 = build(mkRegister8)
+
+def mkPC8(inputs, outputs):
+    in_ = inputs.in_
+    load = inputs.load
+    inc = inputs.inc
+    reset = inputs.reset
+    
+    reseted = lazy()
+    pc = Register8(in_=reseted.out, load=1)
+    
+    nxt = Inc8(in_=pc.out).out
+    inced = Mux8(a=pc.out, b=nxt, sel=inc)
+    loaded = Mux8(a=inced.out, b=in_, sel=load)
+    reseted.set(Mux8(a=loaded.out, b=0, sel=reset))
+    
+    outputs.out = pc.out
+    output.carry_out = And(a=And(a_=Not(in_=load).out, b=Not(in_=reset).out), b=inced.carry_out).out
+
+PC8 = build(mkPC8)
+
+
+# Project 05:
+
+
+
+def mkEightCPU(inputs, outputs):
+    inM = inputs.inM                 # M value input (M = contents of RAM[A])
+    instruction = inputs.instruction # Instruction for execution
+    reset = inputs.reset             # Signals whether to re-start the current
+                                     # program (reset==1) or continue executing
+                                     # the current program (reset==0).
+
+    i, _, _, a, c5, c4, c3, c2, c1, c0, da, dd, dm, jlt, jeq, jgt = [instruction[j] for j in reversed(range(16))]
+
+    # not_i = Not(in_=i).out
+   
+    alu = lazy()
+    # a_reg = Register(in_=Mux16(a=instruction, b=alu.out, sel=i).out, load=Or(a=not_i, b=da).out)
+    # d_reg = Register(in_=alu.out, load=And(a=i, b=dd).out)
+    # jump_lt = And(a=alu.ng, b=jlt).out
+    # jump_eq = And(a=alu.zr, b=jeq).out
+    # jump_gt = And(a=And(a=Not(in_=alu.ng).out, b=Not(in_=alu.zr).out).out, b=jgt).out
+    # jump = And(a=i,
+    #            b=Or(a=jump_lt, b=Or(a=jump_eq, b=jump_gt).out).out
+    #           ).out
+    # pc = PC(in_=a_reg.out, load=jump, inc=1, reset=reset)
+    a_lo_reg = Register8(in_=0, load=0)
+    a_hi_reg = Register8(in_=0, load=0)
+    d_lo_reg = Register8(in_=0, load=0)
+    d_hi_reg = Register8(in_=0, load=0)
+    
+    alu.set(ALU(x=d_reg.out, y=Mux16(a=a_reg.out, b=inM, sel=a).out,
+                zx=c5, nx=c4, zy=c3, ny=c2, f=c1, no=c0))
+
+
+    outputs.outM = alu.out                   # M value output
+    outputs.writeM = And(a=dm, b=i).out      # Write to M?
+    outputs.addressM = a_reg.out             # Address in data memory (of M) (latched)
+    outputs.pc = pc.out                      # address of next instruction (latched)
+    
+EightCPU = build(mkEightCPU)
+
+
+def mkEightComputer(inputs, outputs):
+    reset = inputs.reset
+    
+    cpu = lazy()
+
+    rom = ROM(15)(address=cpu.pc)
+
+    mem = MemorySystem(in_=cpu.outM, load=cpu.writeM, address=cpu.addressM)
+
+    cpu.set(EightCPU(inM=mem.out, instruction=rom.out, reset=reset))
+
+    # HACK: need some dependency to force the whole thing to be synthesized.
+    # Exposing the PC also makes it easy to observe what's happening in a dumb way.
+    outputs.pc = cpu.pc
+    
+EightComputer = build(mkEightComputer)
+
+
+
+import computer
+
+EIGHT_PLATFORM = computer.Platform(
+    chip=EightComputer,
+    assemble=solved_06.assemble,
+    parse_line=solved_07.parse_line,
+    translator=solved_07.Translator)
+
+if __name__ == "__main__":
+    computer.main(EIGHT_PLATFORM)

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -267,7 +267,7 @@ def mkEightCPU(inputs, outputs):
     # For convenience, each half-word in a separate 8-bit register:
     load_a = And_(Or_(not_i, da), bottom_half)
     a_lo_reg = Register8(in_=Mux8(a=split_instr.lo, b=alu_saved.out, sel=i).out, 
-                         load=Or_(not_i, da))
+                         load=load_a)
     a_hi_reg = Register8(in_=Mux8(a=split_instr.hi, b=alu.out, sel=i).out, 
                          load=load_a)
     a_both_reg = Splice(hi=a_hi_reg.out, lo=a_lo_reg.out).out

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -189,8 +189,8 @@ def mkPC8(inputs, outputs):
 
     pc_lo_next = Register8(in_=reseted.out, load=top_half)
     # Note: want reset to happen immediately, but this way probably means some duplication
-    pc_lo = Register8(in_=Mux8(a=Mux8(a=pc_lo_next.out, b=in_lo, sel=load).out, b=0, sel=reset).out, load=Or_(bottom_half, reset, load))
-    pc_hi = Register8(in_=reseted.out, load=bottom_half)
+    pc_lo = Register8(in_=Mux8(a=Mux8(a=pc_lo_next.out, b=in_lo, sel=load).out, b=0, sel=reset).out, load=Or_(bottom_half, reset))
+    pc_hi = Register8(in_=reseted.out, load=Or_(bottom_half, reset))
 
     # Clever? Can tell if overflow happened by inspecting the high bits of the old and new low words.
     carry_in = And(a=pc_lo.out[7], b=Not(in_=pc_lo_next.out[7]).out).out

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -335,12 +335,14 @@ EightComputer = build(mkEightComputer)
 # 8-bit adapters:
 
 def mkSplice(inputs, outputs):
+    """Wiring only: assemble two 8-bit signals into a 16-bit signal."""
     for i in range(8):
         outputs.out[i] = inputs.lo[i]
         outputs.out[i+8] = inputs.hi[i]
 Splice = build(mkSplice)
 
 def mkSplit(inputs, outputs):
+    """Wiring only: extract two 8-bit signals from a 16-bit signal."""
     for i in range(8):
         outputs.lo[i] = inputs.in_[i]
         outputs.hi[i] = inputs.in_[i+8]

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -163,7 +163,7 @@ Register8 = build(mkRegister8)
 def mkPC8(inputs, outputs):
     """16-bit PC, built from two 8-bit registers and a single Inc8.
 
-    On the first half-cycle, the low half-word is incremented, but the output is not yet updated. 
+    On the first half-cycle, the low half-word is incremented but not yet stored.
     On the second half-cycle, the high half-word is incremented, and then the two half-words 
     appear together at the same time.
 

--- a/alt/eight.py
+++ b/alt/eight.py
@@ -46,8 +46,8 @@ from nand.solutions.solved_01 import And, Or, Not, Xor, Mux, Mux16
 from nand.solutions.solved_02 import HalfAdder, FullAdder
 from nand.solutions.solved_03 import Bit
 from nand.solutions.solved_05 import MemorySystem, PC
-from nand.solutions import solved_06
-from nand.solutions import solved_07
+from nand.solutions import solved_06, solved_07
+import project_08
 
 
 # Project 01:
@@ -366,7 +366,7 @@ EIGHT_PLATFORM = computer.Platform(
     chip=EightComputer,
     assemble=solved_06.assemble,
     parse_line=solved_07.parse_line,
-    translator=solved_07.Translator)
+    translator=project_08.Translator)  # Note: solved_07.Translator doesn't work when used this way.
 
 if __name__ == "__main__":
     computer.main(EIGHT_PLATFORM)

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -427,7 +427,7 @@ def test_gates_register8():
 
 def test_gates_pc8():
     assert gate_count(PC8) == {
-        'nands': 270,  # Compare to 287. Not much savings here.
+        'nands': 266,  # Compare to 287. Not much savings here.
         'dffs': 24,    # This is actually 8 _more_.
     }
 
@@ -669,6 +669,7 @@ def test_backward_compatible_cpu():
     for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -32768
 
+    # Reset is effective in a single clock:
     cpu.reset = 1
     cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 0 # and DRegister == 1
@@ -692,7 +693,7 @@ def test_backward_compatible_speed():
 
 def test_computer_gates():
    assert gate_count(EightComputer) == {
-       'nands': 1070,  # ??? compare to 1262
+       'nands': 1032,  # ??? compare to 1262
        'dffs': 67,  # 3*16 bits (as in the standard CPU), plus two more half-words to hold results between half-cycle, plus a handful more to track some odd bits
        'roms': 1,
        'rams': 2,

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -435,7 +435,7 @@ def test_gates_pc8():
 #
 
 def test_backward_compatible_cpu():
-    test_05.test_cpu(EightCPU)
+    test_05.test_cpu(EightCPU, cycles_per_instr=2)
 
 def test_backward_compatible_computer_add():
     test_05.test_computer_add(EightComputer)
@@ -444,7 +444,7 @@ def test_backward_compatible_computer_max():
     test_05.test_computer_max(EightComputer, cycles_per_instr=2)
     
 def test_backward_compatible_speed():
-    test_05.test_speed(EightComputer)
+    test_05.test_speed(EightComputer, cycles_per_instr=2)
 
 
 

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -413,7 +413,7 @@ def test_pc8(run):
     assert pc.out == 1
 
     pc.in_ = 22222; pc.reset = 1
-    top(); bottom()
+    top()   # Note: reset is effective immediately, without waiting for bottom_half
     assert pc.out == 0
 
 
@@ -441,7 +441,7 @@ def test_backward_compatible_computer_add():
     test_05.test_computer_add(EightComputer)
     
 def test_backward_compatible_computer_max():
-    test_05.test_computer_max(EightComputer)
+    test_05.test_computer_max(EightComputer, cycles_per_instr=2)
     
 def test_backward_compatible_speed():
     test_05.test_speed(EightComputer)

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -1,0 +1,326 @@
+import pytest
+
+from nand import run, gate_count #, unsigned
+import test_05
+import test_07
+import test_08
+import test_optimal_08
+
+from alt.eight import *
+
+
+#
+# Components:
+#
+
+
+def test_not8():
+    assert unsigned(run(Not8, in_=0b0000_0000).out) == 0b1111_1111
+    assert unsigned(run(Not8, in_=0b1111_1111).out) == 0b0000_0000
+    assert unsigned(run(Not8, in_=0b1010_1010).out) == 0b0101_0101
+    assert unsigned(run(Not8, in_=0b1100_0011).out) == 0b0011_1100
+    assert unsigned(run(Not8, in_=0b0011_0100).out) == 0b1100_1011
+
+def test_and8():
+    assert unsigned(run(And8, a=0b0000_0000, b=0b0000_0000).out) == 0b0000_0000
+    assert unsigned(run(And8, a=0b0000_0000, b=0b1111_1111).out) == 0b0000_0000
+    assert unsigned(run(And8, a=0b1111_1111, b=0b1111_1111).out) == 0b1111_1111
+    assert unsigned(run(And8, a=0b1010_1010, b=0b0101_0101).out) == 0b0000_0000
+    assert unsigned(run(And8, a=0b1100_0011, b=0b1111_0000).out) == 0b1100_0000
+    assert unsigned(run(And8, a=0b0011_0100, b=0b0111_0110).out) == 0b0011_0100
+
+def test_mux8():
+    assert unsigned(run(Mux8, a=0b0000_0000, b=0b0000_0000, sel=0).out) == 0b0000_0000
+    assert unsigned(run(Mux8, a=0b0000_0000, b=0b0000_0000, sel=1).out) == 0b0000_0000
+    assert unsigned(run(Mux8, a=0b0000_0000, b=0b0011_0100, sel=0).out) == 0b0000_0000
+    assert unsigned(run(Mux8, a=0b0000_0000, b=0b0011_0100, sel=1).out) == 0b0011_0100
+    assert unsigned(run(Mux8, a=0b0111_0110, b=0b0000_0000, sel=0).out) == 0b0111_0110
+    assert unsigned(run(Mux8, a=0b0111_0110, b=0b0000_0000, sel=1).out) == 0b0000_0000
+    assert unsigned(run(Mux8, a=0b1010_1010, b=0b0101_0101, sel=0).out) == 0b1010_1010
+    assert unsigned(run(Mux8, a=0b1010_1010, b=0b0101_0101, sel=1).out) == 0b0101_0101
+
+def test_gates_not8():
+    assert gate_count(Not8)['nands'] == 8
+
+def test_gates_and8():
+    assert gate_count(And8)['nands'] == 16
+
+def test_gates_mux8():
+    assert gate_count(Mux8)['nands'] == 25  # optimal?
+
+
+
+# Project 02:
+
+@pytest.mark.parametrize("simulator", ["vector", "codegen"])
+def test_inc8(simulator):
+    assert run(Inc8, in_=  0, carry_in=0, simulator=simulator).out == 0
+    assert run(Inc8, in_=  5, carry_in=0, simulator=simulator).out == 5
+    assert run(Inc8, in_=255, carry_in=0, simulator=simulator).out == 255
+    assert run(Inc8, in_=  0, carry_in=1, simulator=simulator).out == 1
+    assert run(Inc8, in_=  5, carry_in=1, simulator=simulator).out == 6
+    assert run(Inc8, in_=255, carry_in=1, simulator=simulator).out == 0
+
+    # TODO: what to do with negatives? Probably need to treat these value as unsigned until they're 
+    # re-assembled into 16-bits.
+    # assert run(Inc8, in_=-1, simulator=simulator).out ==  0
+    # assert run(Inc8, in_=-5, simulator=simulator).out == -4
+    
+    assert run(Inc8, in_=  0, carry_in=0, simulator=simulator).carry_out == 0
+    assert run(Inc8, in_=255, carry_in=0, simulator=simulator).carry_out == 0
+    assert run(Inc8, in_=  0, carry_in=1, simulator=simulator).carry_out == 0
+    assert run(Inc8, in_=255, carry_in=1, simulator=simulator).carry_out == 1
+    
+@pytest.mark.parametrize("simulator", ["vector", "codegen"])
+def test_add8(simulator):
+    assert run(Add8, a=  0, b=  0, carry_in=0, simulator=simulator).out ==   0
+    assert run(Add8, a=255, b=255, carry_in=0, simulator=simulator).out == 254
+    assert run(Add8, a=  0, b=  0, carry_in=1, simulator=simulator).out ==   1
+    assert run(Add8, a=255, b=255, carry_in=1, simulator=simulator).out == 255
+    
+    assert run(Add8, a=  0, b=  0, carry_in=0, simulator=simulator).carry_out == False
+    assert run(Add8, a=255, b=255, carry_in=0, simulator=simulator).carry_out == True
+    assert run(Add8, a=  0, b=  0, carry_in=1, simulator=simulator).carry_out == False
+    assert run(Add8, a=255, b=255, carry_in=1, simulator=simulator).carry_out == True
+
+@pytest.mark.parametrize("simulator", ["vector", "codegen"])
+def test_zero8(simulator):
+    assert run(Zero8, in_=0, simulator=simulator).out == True
+    
+    z = run(Zero8, simulator=simulator)
+    for i in range(1, 256):
+        z.in_ = i
+        assert z.out == False
+
+
+def test_alu_nostat():
+    alu = run(EightALU)
+    
+    alu.x = 0
+    alu.y = -1 
+    
+    alu.zx = 1; alu.nx = 0; alu.zy = 1; alu.ny = 0; alu.f = 1; alu.no = 0; assert alu.out == 0   # 0
+    alu.zx = 1; alu.nx = 1; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 1   # 1
+    alu.zx = 1; alu.nx = 1; alu.zy = 1; alu.ny = 0; alu.f = 1; alu.no = 0; assert alu.out == 255  # -1
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 0; alu.no = 0; assert alu.out == 0   # X
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 0; assert alu.out == 255  # Y
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 0; alu.no = 1; assert alu.out == 255  # !X
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 1; assert alu.out == 0   # !Y
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 0   # -X
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 1; assert alu.out == 1   # -Y
+    alu.zx = 0; alu.nx = 1; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 1   # X + 1
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 0   # Y + 1
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 0; assert alu.out == 255  # X - 1
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 0; assert alu.out == 254  # Y - 1
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 0; assert alu.out == 255  # X + Y
+    alu.zx = 0; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 1; assert alu.out == 1   # X - Y
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 255  # Y - X
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 0; assert alu.out == 0   # X & Y
+    alu.zx = 0; alu.nx = 1; alu.zy = 0; alu.ny = 1; alu.f = 0; alu.no = 1; assert alu.out == 255  # X | Y
+
+
+    alu.x = 23  # 0x17
+    alu.y = 45  # 0x2D
+    
+    alu.zx = 1; alu.nx = 0; alu.zy = 1; alu.ny = 0; alu.f = 1; alu.no = 0; assert alu.out == 0      # 0
+    alu.zx = 1; alu.nx = 1; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 1      # 1
+    alu.zx = 1; alu.nx = 1; alu.zy = 1; alu.ny = 0; alu.f = 1; alu.no = 0; assert alu.out == 255     # -1
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 0; alu.no = 0; assert alu.out == 23  # X
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 0; assert alu.out == 45   # Y
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 0; alu.no = 1; assert alu.out == 0xE8 # !X
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 1; assert alu.out == 0xD2 # !Y
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 256-23 # -X
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 1; assert alu.out == 256-45  # -Y
+    alu.zx = 0; alu.nx = 1; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 24  # X + 1
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 46   # Y + 1
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 0; assert alu.out == 22  # X - 1
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 0; assert alu.out == 44   # Y - 1
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 0; assert alu.out == 68  # X + Y
+    alu.zx = 0; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 1; assert alu.out == 256-22  # X - Y
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 1; alu.f = 1; alu.no = 1; assert alu.out == 22 # Y - X
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 0; assert alu.out == 0x05 # X & Y
+    alu.zx = 0; alu.nx = 1; alu.zy = 0; alu.ny = 1; alu.f = 0; alu.no = 1; assert alu.out == 0x3F # X | Y
+
+
+# TODO: Need to sort out what happens with negatives here
+def test_alu():
+    alu = run(EightALU)
+
+    alu.x = 0
+    alu.y = -1 
+
+    alu.zx = 1; alu.nx = 0; alu.zy = 1; alu.ny = 0; alu.f = 1; alu.no = 0  # 0
+    assert alu.out == 0 and alu.zr == 1 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1  # 1
+    assert alu.out == 1 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 1; alu.ny = 0; alu.f = 1; alu.no = 0  # -1
+    assert alu.out == -1 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 0; alu.no = 0  # X
+    assert alu.out == 0 and alu.zr == 1 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 0  # Y
+    assert alu.out == -1 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 0; alu.no = 1  # !X
+    assert alu.out == -1 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 1  # !Y
+    assert alu.out == 0 and alu.zr == 1 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1  # -X
+    assert alu.out == 0 and alu.zr == 1 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 1  # -Y
+    assert alu.out == 1 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 1; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1  # X + 1
+    assert alu.out == 1 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 1; alu.f = 1; alu.no = 1  # Y + 1
+    assert alu.out == 0 and alu.zr == 1 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 0  # X - 1
+    assert alu.out == -1 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 0  # Y - 1
+    assert alu.out == -2 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 0  # X + Y
+    assert alu.out == -1 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 0; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 1  # X - Y
+    assert alu.out == 1 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 1; alu.f = 1; alu.no = 1  # Y - X
+    assert alu.out == -1 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 0  # X & Y
+    assert alu.out == 0 and alu.zr == 1 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 1; alu.zy = 0; alu.ny = 1; alu.f = 0; alu.no = 1  # X | Y
+    assert alu.out == -1 and alu.zr == 0 and alu.ng == 1
+
+
+    alu.x = 17
+    alu.y = 3 
+
+    alu.zx = 1; alu.nx = 0; alu.zy = 1; alu.ny = 0; alu.f = 1; alu.no = 0  # 0
+    assert alu.out == 0 and alu.zr == 1 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1  # 1
+    assert alu.out == 1 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 1; alu.ny = 0; alu.f = 1; alu.no = 0  # -1
+    assert alu.out == -1 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 0; alu.no = 0  # X
+    assert alu.out == 17 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 0  # Y
+    assert alu.out == 3 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 0; alu.no = 1  # !X
+    assert alu.out == -18 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 1  # !Y
+    assert alu.out == -4 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1  # -X
+    assert alu.out == -17 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 1  # -Y
+    assert alu.out == -3 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 0; alu.nx = 1; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 1  # X + 1
+    assert alu.out == 18 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 1; alu.f = 1; alu.no = 1  # Y + 1
+    assert alu.out == 4 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 1; alu.ny = 1; alu.f = 1; alu.no = 0  # X - 1
+    assert alu.out == 16 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 1; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 0  # Y - 1
+    assert alu.out == 2 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 0  # X + Y
+    assert alu.out == 20 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 1; alu.zy = 0; alu.ny = 0; alu.f = 1; alu.no = 1  # X - Y
+    assert alu.out == 14 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 1; alu.f = 1; alu.no = 1  # Y - X
+    assert alu.out == -14 and alu.zr == 0 and alu.ng == 1
+
+    alu.zx = 0; alu.nx = 0; alu.zy = 0; alu.ny = 0; alu.f = 0; alu.no = 0  # X & Y
+    assert alu.out == 1 and alu.zr == 0 and alu.ng == 0
+
+    alu.zx = 0; alu.nx = 1; alu.zy = 0; alu.ny = 1; alu.f = 0; alu.no = 1  # X | Y
+    assert alu.out == 19 and alu.zr == 0 and alu.ng == 0
+
+
+def test_gates_inc8():
+    assert gate_count(Inc8)['nands'] == 40  # gate_count(Inc16)/2 + 2
+
+def test_gates_add8():
+    assert gate_count(Add8)['nands'] == 72  # gate_count(Add16)/2 + 2
+
+def test_gates_zero8():
+    assert gate_count(Zero8)['nands'] == 22  # gate_count(Zero16)/2 - 1
+
+def test_gates_alu():
+    assert gate_count(EightALU)['nands'] == 286  # gate_count(ALU)/2 + 6
+    
+
+# Project 03:
+
+
+#
+# First test that the new CPU executes all Hack instructions as expected:
+#
+
+def test_backward_compatible_cpu():
+    test_05.test_cpu(EightCPU)
+
+def test_backward_compatible_computer_add():
+    test_05.test_computer_add(EightComputer)
+    
+def test_backward_compatible_computer_max():
+    test_05.test_computer_max(EightComputer)
+    
+def test_backward_compatible_speed():
+    test_05.test_speed(EightComputer)
+
+
+
+def test_computer_gates():
+   assert gate_count(EightComputer) == {
+       'nands': 1262,  # ??? compare to 1262
+       'dffs': 64,  # 4 registers
+       'roms': 1,
+       'rams': 2,
+       'inputs': 1,
+   }
+
+
+
+#
+# Performance. TL;DR, it's worse.
+#
+
+@pytest.mark.skip(reason="Sources aren't in the repo yet")
+def test_pong_first_iteration():
+    cycles = test_optimal_08.count_pong_cycles_first_iteration(EightComputer, solved_06.assemble, Translator)
+
+    assert cycles < 70_000
+
+
+@pytest.mark.skip(reason="Sources aren't in the repo yet")
+def test_vm_cycles_to_init():
+    cycles = test_optimal_08.count_cycles_to_init(solved_05.Computer, solved_06.assemble, Translator)
+
+    # compare to the project_08 solution (about 4m)
+    assert cycles < 8_000_000

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -700,6 +700,44 @@ def test_computer_gates():
    }
 
 
+#
+# VM translator:
+#
+
+def test_vm_simple_add():
+    test_07.test_simple_add(chip=EightComputer, simulator='vector')
+
+def test_vm_stack_ops():
+    test_07.test_stack_ops(chip=EightComputer, simulator='vector')
+
+def test_vm_memory_access_basic():
+    test_07.test_memory_access_basic(chip=EightComputer, simulator='vector')
+
+def test_vm_memory_access_pointer():
+    test_07.test_memory_access_pointer(chip=EightComputer, simulator='vector')
+
+def test_vm_memory_access_static():
+    test_07.test_memory_access_static(chip=EightComputer, simulator='vector')
+
+
+def test_vm_basic_loop():
+    test_08.test_basic_loop(chip=EightComputer, simulator='vector')
+
+def test_vm_fibonacci_series():
+    test_08.test_fibonacci_series(chip=EightComputer, simulator='vector')
+    
+def test_vm_simple_function():
+    test_08.test_simple_function(chip=EightComputer, simulator='vector')
+    
+def test_vm_nested_call():
+    test_08.test_nested_call(chip=EightComputer, simulator='vector')
+
+def test_vm_fibonacci_element():
+    test_08.test_fibonacci_element(chip=EightComputer, simulator='vector')
+
+def test_vm_statics_multiple_files():
+    test_08.test_statics_multiple_files(chip=EightComputer, simulator='vector')
+
 
 #
 # Performance. TL;DR, it's worse.

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -277,6 +277,123 @@ def test_gates_alu():
 
 # Project 03:
 
+def test_register8():
+    reg = run(Register8)
+
+    reg.in_ = 0
+    reg.load = 0
+    reg.tick(); reg.tock()
+    assert reg.out == 0
+
+    reg.load = 1
+    reg.tick(); reg.tock()
+    assert reg.out == 0
+
+    reg.in_ = 123
+    reg.load = 0
+    reg.tick(); reg.tock()
+    assert reg.out == 0
+
+    reg.in_ = 111
+    reg.load = 0
+    reg.tick(); reg.tock()
+    assert reg.out == 0
+
+    reg.in_ = 123
+    reg.load = 1
+    reg.tick(); reg.tock()
+    assert reg.out == 123
+
+    reg.load = 0
+    reg.tick(); reg.tock()
+    assert reg.out == 123
+
+    reg.in_ = -1
+    reg.tick(); reg.tock()
+    assert reg.out == 123
+
+def test_pc8():
+    pc = run(PC8)
+
+    def top():
+        pc.top_half = True
+        pc.bottom_half = False
+        pc.ticktock()
+    def bottom():
+        pc.top_half = False
+        pc.bottom_half = True
+        pc.ticktock()
+
+    pc.in_ = 0; pc.reset = 0; pc.load = 0
+    top()
+    assert pc.out == 0  # No change on the first half-cycle
+    bottom()
+    assert pc.out == 1  # Now we go forward one word
+
+    pc.in_ = -32123
+    top(); bottom()
+    assert pc.out == 2
+
+    pc.load = 1
+    top(); bottom()
+    assert pc.out == -32123
+
+    pc.load = 0
+    top(); bottom()
+    assert pc.out == -32122
+
+    top(); bottom()
+    assert pc.out == -32121
+
+    pc.in_ = 12345; pc.load = 1
+    top(); bottom()
+    assert pc.out == 12345
+
+    pc.reset = 1
+    top(); bottom()
+    assert pc.out == 0  # reset overrides load/in_
+
+    pc.reset = 0
+    top(); bottom()
+    assert pc.out == 12345  # load/in_ still set from before
+
+    pc.reset = 1
+    top(); bottom()
+    assert pc.out == 0
+
+    pc.reset = 0; pc.load = 0
+    top(); bottom()
+    assert pc.out == 1
+
+    pc.reset = 1
+    top(); bottom()
+    assert pc.out == 0
+
+    pc.in_ = 0; pc.reset = 0; pc.load = 1
+    top(); bottom()
+    assert pc.out == 0
+
+    pc.load = 0
+    top(); bottom()
+    assert pc.out == 1
+
+    pc.in_ = 22222; pc.reset = 1
+    top(); bottom()
+    assert pc.out == 0
+
+
+def test_gates_register8():
+    assert gate_count(Register8) == {
+        'nands': 32,  # ?
+        'dffs': 8
+    }
+
+def test_gates_pc8():
+    assert gate_count(PC8) == {
+        'nands': 242,  # Compare to 287. Not much savings here.
+        'dffs': 24,    # This is actually 8 _more_.
+    }
+
 
 #
 # First test that the new CPU executes all Hack instructions as expected:

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -694,7 +694,7 @@ def test_backward_compatible_speed():
 def test_computer_gates():
    assert gate_count(EightComputer) == {
        'nands': 1032,  # ??? compare to 1262
-       'dffs': 67,  # 3*16 bits (as in the standard CPU), plus two more half-words to hold results between half-cycle, plus a handful more to track some odd bits
+       'dffs': 67,  # 3*16 bits (as in the standard CPU), plus two more half-words to hold results between half-cycles, plus a handful more to track some odd bits
        'roms': 1,
        'rams': 2,
        'inputs': 1,

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -380,8 +380,10 @@ def test_pc8(run):
     top(); bottom()
     assert pc.out == -32121
 
+    # Tricky: jump target shows up in the bottom half and has to overwrite both halves of the PC
+    top()
     pc.in_ = 12345; pc.load = 1
-    top(); bottom()
+    bottom()
     assert pc.out == 12345
 
     pc.reset = 1

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -425,7 +425,7 @@ def test_gates_register8():
 
 def test_gates_pc8():
     assert gate_count(PC8) == {
-        'nands': 242,  # Compare to 287. Not much savings here.
+        'nands': 270,  # Compare to 287. Not much savings here.
         'dffs': 24,    # This is actually 8 _more_.
     }
 
@@ -450,8 +450,8 @@ def test_backward_compatible_speed():
 
 def test_computer_gates():
    assert gate_count(EightComputer) == {
-       'nands': 1262,  # ??? compare to 1262
-       'dffs': 64,  # 4 registers
+       'nands': 1070,  # ??? compare to 1262
+       'dffs': 67,  # 3*16 bits (as in the standard CPU), plus two more half-words to hold results between half-cycle, plus a handful more to track some odd bits
        'roms': 1,
        'rams': 2,
        'inputs': 1,

--- a/nand/translate.py
+++ b/nand/translate.py
@@ -66,6 +66,7 @@ class AssemblySource:
 
         if stop_cycles is None:
             stop_cycles = self.instruction_count
+        stop_cycles *= 2
 
         if debug:
             # print_lines(self.lines)

--- a/nand/vector.py
+++ b/nand/vector.py
@@ -589,3 +589,9 @@ class NandVectorComputerWrapper(NandVectorWrapper):
     def set_keydown(self, keycode):
         """Provide the code which identifies a single key which is currently pressed."""
         self._keyboard.value = keycode
+
+    # Tricky: SP might get special treatment in some implementations, so provide a named property
+    # that subclasses can override.
+    @property
+    def sp(self):
+        return self.peek(0)

--- a/nand/vector.py
+++ b/nand/vector.py
@@ -230,7 +230,9 @@ class RAMOps(VectorOps):
         def write(traces):
             load_val = tst_trace(load[0], traces)
             if load_val:
-                in_val = get_multiple_traces(in_, traces)
+                # Tricky: sign extension was never needed here until eight.py, and it will 
+                # hurt performance slightly.
+                in_val = extend_sign(get_multiple_traces(in_, traces))
                 address_val = get_multiple_traces(address, traces)
                 self.set(address_val, in_val)
             return traces

--- a/project_02.py
+++ b/project_02.py
@@ -35,6 +35,8 @@ FullAdder = build(mkFullAdder)
 
 
 def mkInc16(inputs, outputs):
+    """Add one to a single 16-bit input, ignoring overflow."""
+
     in_ = inputs.in_
 
     # SOLVERS: replace this with one or more Nands and/or components defined above
@@ -46,6 +48,8 @@ Inc16 = build(mkInc16)
 
 
 def mkAdd16(inputs, outputs):
+    """Add two 16-bit inputs, ignoring overflow."""
+
     a = inputs.a
     b = inputs.b
 
@@ -58,6 +62,8 @@ Add16 = build(mkAdd16)
 
 
 def mkZero16(inputs, outputs):
+    """Test whether a single 16-bit input has the value 0."""
+
     in_ = inputs.in_
 
     # SOLVERS: replace this with one or more Nands and/or components defined above
@@ -68,22 +74,39 @@ def mkZero16(inputs, outputs):
 Zero16 = build(mkZero16)
 
 
+def mkNeg16(inputs, outputs):
+    """Test whether a single 16-bit input is negative."""
+    
+    in_ = inputs.in_
+
+    # SOLVERS: replace this with one or more Nands and/or components defined above
+    n1 = solved_02.Neg16(in_=in_)
+
+    outputs.out = n1.out
+
+Neg16 = build(mkNeg16)
+
+
 def mkALU(inputs, outputs):
+    """Combine two 16-bit inputs according to six control bits, producing a 16-bit result and two 
+    condition codes.
+    """
+    
     x = inputs.x
     y = inputs.y
 
-    zx = inputs.zx
-    nx = inputs.nx
-    zy = inputs.zy
-    ny = inputs.ny
-    f  = inputs.f
-    no = inputs.no
+    zx = inputs.zx  # X is replaced by 0
+    nx = inputs.nx  # X (or 0) is negated
+    zy = inputs.zy  # Y is replaced by 0
+    ny = inputs.ny  # Y (or 0) is negated
+    f  = inputs.f   # if True, combine inputs with Add, otherwise, And
+    no = inputs.no  # negate the output
 
     # SOLVERS: replace this with one or more Nands and/or components defined above
     n1 = solved_02.ALU(x=x, y=y, zx=zx, nx=nx, zy=zy, ny=ny, f=f, no=no)
 
-    outputs.out = n1.out
-    outputs.zr = n1.zr
-    outputs.ng = n1.ng
+    outputs.out = n1.out  # the resulting value
+    outputs.zr = n1.zr    # is the output equal to 0?
+    outputs.ng = n1.ng    # is the output negative?
     
 ALU = build(mkALU)

--- a/test_02.py
+++ b/test_02.py
@@ -116,8 +116,8 @@ def test_alu_nostat():
     alu.zx = 0; alu.nx = 1; alu.zy = 0; alu.ny = 1; alu.f = 0; alu.no = 1; assert unsigned(alu.out) == 0x5FF2 # X | Y
 
 
-def test_alu():
-    alu = run(ALU)
+def test_alu(chip=ALU):
+    alu = run(chip)
 
     alu.x = 0
     alu.y = -1 

--- a/test_02.py
+++ b/test_02.py
@@ -61,6 +61,12 @@ def test_zero16():
     for i in range(16):
         assert run(Zero16, in_=(1 << i)).out == False
 
+def test_neg16():
+    assert run(Neg16, in_=      0).out == False
+    assert run(Neg16, in_=  32767).out == False
+    assert run(Neg16, in_=     -1).out == True
+    assert run(Neg16, in_= -32768).out == True
+
 def test_alu_nostat():
     alu = run(ALU)
     

--- a/test_05.py
+++ b/test_05.py
@@ -364,7 +364,7 @@ MAX_PROGRAM = [
     0b1110101010000111,  # 15: JMP    ; infinite loop
 ]
 
-def test_computer_max(chip=project_05.Computer):
+def test_computer_max(chip=project_05.Computer, cycles_per_instr=1):
     computer = run(chip)
 
     computer.init_rom(MAX_PROGRAM)
@@ -372,8 +372,8 @@ def test_computer_max(chip=project_05.Computer):
     # first run: compute max(3,5)
     computer.poke(1, 3)
     computer.poke(2, 5)
-    for _ in range(14):
-        computer.ticktock()    
+    for _ in range(14*cycles_per_instr):
+        computer.ticktock()
     assert computer.peek(3) == 5
 
     # second run: compute max(23456,12345)
@@ -381,8 +381,8 @@ def test_computer_max(chip=project_05.Computer):
     computer.poke(1, 23456)
     computer.poke(2, 12345)
     # The run on these inputs needs less cycles (different branching)
-    for _ in range(10):
-        computer.ticktock()    
+    for _ in range(10*cycles_per_instr):
+        computer.ticktock()
     assert computer.peek(3) == 23456
 
  

--- a/test_05.py
+++ b/test_05.py
@@ -108,35 +108,35 @@ def test_memory_system():
     assert mem.out == -1
 
 
-def test_cpu(chip=project_05.CPU):
+def test_cpu(chip=project_05.CPU, cycles_per_instr=1):
     cpu = run(chip)
 
     cpu.instruction = 0b0011000000111001  # @12345
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 12345 and cpu.pc == 1 # and DRegister == 0
 
     cpu.instruction = 0b1110110000010000  # D=A
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 12345 and cpu.pc == 2 # and DRegister == 12345
 
     cpu.instruction = 0b0101101110100000  # @23456
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 23456 and cpu.pc == 3 # and DRegister == 12345
 
     cpu.instruction = 0b1110000111010000  # D=A-D
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 23456 and cpu.pc == 4 # and DRegister == 11111
 
     cpu.instruction = 0b0000001111101000  # @1000
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 5 # and DRegister == 11111
 
     cpu.instruction = 0b1110001100001000  # M=D
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.outM == 11111 and cpu.writeM == 1 and cpu.addressM == 1000 and cpu.pc == 6 # and DRegister == 11111
 
     cpu.instruction = 0b0000001111101001  # @1001
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1001 and cpu.pc == 7 # and DRegister == 11111
 
     # Note confusing timing here: outM has the value to be written to memory when the clock falls. Afterward,
@@ -144,161 +144,161 @@ def test_cpu(chip=project_05.CPU):
     # TODO: always assert outM and writeM before tick/tock?
     cpu.instruction = 0b1110001110011000  # MD=D-1
     assert cpu.outM == 11110 and cpu.writeM == 1 and cpu.addressM == 1001 and cpu.pc == 7 # and DRegister == 11111
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.outM == 11109 and cpu.writeM == 1 and cpu.addressM == 1001 and cpu.pc == 8 # and DRegister == 11110
 
     cpu.instruction = 0b0000001111101000  # @1000
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 9 # and DRegister == 11110
 
     cpu.instruction = 0b1111010011010000  # D=D-M
     cpu.inM = 11111
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 10 # and DRegister == -1
 
     cpu.instruction = 0b0000000000001110  # @14
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 14 and cpu.pc == 11 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000100  # D;jlt
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 14 and cpu.pc == 14 # and DRegister == -1
 
     cpu.instruction = 0b0000001111100111  # @999
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 999 and cpu.pc == 15 # and DRegister == -1
 
     cpu.instruction = 0b1110110111100000  # A=A+1
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 16 # and DRegister == -1
 
     cpu.instruction = 0b1110001100001000  # M=D
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.outM == -1 and cpu.writeM == 1 and cpu.addressM == 1000 and cpu.pc == 17 # and DRegister == -1
 
     cpu.instruction = 0b0000000000010101  # @21
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 21 and cpu.pc == 18 # and DRegister == -1
 
     cpu.instruction = 0b1110011111000010  # D+1;jeq
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 21 and cpu.pc == 21 # and DRegister == -1
 
     cpu.instruction = 0b0000000000000010  # @2
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 2 and cpu.pc == 22 # and DRegister == -1
 
     cpu.instruction = 0b1110000010010000  # D=D+A
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 2 and cpu.pc == 23 # and DRegister == 1
 
     cpu.instruction = 0b0000001111101000  # @1000
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 24 # and DRegister == -1
 
     cpu.instruction = 0b1110111010010000  # D=-1
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 25 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000001  # D;JGT
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 26 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000010  # D;JEQ
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 27 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000011  # D;JGE
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 28 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000100  # D;JLT
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000101  # D;JNE
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000110  # D;JLE
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000111  # D;JMP
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
     cpu.instruction = 0b1110101010010000  # D=0
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000001  # D;JGT
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1002 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000010  # D;JEQ
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000011  # D;JGE
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000100  # D;JLT
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000101  # D;JNE
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1002 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000110  # D;JLE
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000111  # D;JMP
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
     cpu.instruction = 0b1110111111010000  # D=1
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000001  # D;JGT
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000010  # D;JEQ
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000011  # D;JGE
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000100  # D;JLT
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000101  # D;JNE
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000110  # D;JLE
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000111  # D;JMP
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
     cpu.reset = 1
-    cpu.tick(); cpu.tock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 0 # and DRegister == 1
 
     cpu.instruction = 0b0111111111111111  # @32767
     cpu.reset = 0
-    cpu.tick(); cpu.tock()
+    for _ in range(cycles_per_instr): cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 32767 and cpu.pc == 1 # and DRegister == 1
 
 
@@ -386,7 +386,7 @@ def test_computer_max(chip=project_05.Computer, cycles_per_instr=1):
     assert computer.peek(3) == 23456
 
  
-def cycles_per_second(chip):
+def cycles_per_second(chip, cycles_per_instr=1):
     """Estimate the speed of CPU simulation by running Max repeatedly with random input.
     """
     
@@ -397,22 +397,24 @@ def cycles_per_second(chip):
 
     computer.init_rom(MAX_PROGRAM)
 
+    CYCLES = 14*cycles_per_instr
+
     def once():
         x = random.randint(0, 0x7FFF)
         y = random.randint(0, 0x7FFF)
         computer.reset_program()
         computer.poke(1, x)
         computer.poke(2, y)
-        for _ in range(14):
+        for _ in range(CYCLES):
             computer.ticktock()
         assert computer.peek(3) == max(x, y)
 
     count, time = timeit.Timer(once).autorange()
 
-    return count*14/time
+    return count*CYCLES/time
 
 
-def test_speed(chip=project_05.Computer):
-    cps = cycles_per_second(chip)
+def test_speed(chip=project_05.Computer, cycles_per_instr=1):
+    cps = cycles_per_second(chip, cycles_per_instr)
     print(f"Measured speed: {cps:0,.1f} cycles/s")
     assert cps > 1000

--- a/test_05.py
+++ b/test_05.py
@@ -108,35 +108,35 @@ def test_memory_system():
     assert mem.out == -1
 
 
-def test_cpu(chip=project_05.CPU, cycles_per_instr=1):
+def test_cpu(chip=project_05.CPU):
     cpu = run(chip)
 
     cpu.instruction = 0b0011000000111001  # @12345
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 12345 and cpu.pc == 1 # and DRegister == 0
 
     cpu.instruction = 0b1110110000010000  # D=A
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 12345 and cpu.pc == 2 # and DRegister == 12345
 
     cpu.instruction = 0b0101101110100000  # @23456
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 23456 and cpu.pc == 3 # and DRegister == 12345
 
     cpu.instruction = 0b1110000111010000  # D=A-D
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 23456 and cpu.pc == 4 # and DRegister == 11111
 
     cpu.instruction = 0b0000001111101000  # @1000
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 5 # and DRegister == 11111
 
     cpu.instruction = 0b1110001100001000  # M=D
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.outM == 11111 and cpu.writeM == 1 and cpu.addressM == 1000 and cpu.pc == 6 # and DRegister == 11111
 
     cpu.instruction = 0b0000001111101001  # @1001
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1001 and cpu.pc == 7 # and DRegister == 11111
 
     # Note confusing timing here: outM has the value to be written to memory when the clock falls. Afterward,
@@ -144,152 +144,152 @@ def test_cpu(chip=project_05.CPU, cycles_per_instr=1):
     # TODO: always assert outM and writeM before tick/tock?
     cpu.instruction = 0b1110001110011000  # MD=D-1
     assert cpu.outM == 11110 and cpu.writeM == 1 and cpu.addressM == 1001 and cpu.pc == 7 # and DRegister == 11111
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.outM == 11109 and cpu.writeM == 1 and cpu.addressM == 1001 and cpu.pc == 8 # and DRegister == 11110
 
     cpu.instruction = 0b0000001111101000  # @1000
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 9 # and DRegister == 11110
 
     cpu.instruction = 0b1111010011010000  # D=D-M
     cpu.inM = 11111
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 10 # and DRegister == -1
 
     cpu.instruction = 0b0000000000001110  # @14
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 14 and cpu.pc == 11 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000100  # D;jlt
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 14 and cpu.pc == 14 # and DRegister == -1
 
     cpu.instruction = 0b0000001111100111  # @999
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 999 and cpu.pc == 15 # and DRegister == -1
 
     cpu.instruction = 0b1110110111100000  # A=A+1
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 16 # and DRegister == -1
 
     cpu.instruction = 0b1110001100001000  # M=D
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.outM == -1 and cpu.writeM == 1 and cpu.addressM == 1000 and cpu.pc == 17 # and DRegister == -1
 
     cpu.instruction = 0b0000000000010101  # @21
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 21 and cpu.pc == 18 # and DRegister == -1
 
     cpu.instruction = 0b1110011111000010  # D+1;jeq
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 21 and cpu.pc == 21 # and DRegister == -1
 
     cpu.instruction = 0b0000000000000010  # @2
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 2 and cpu.pc == 22 # and DRegister == -1
 
     cpu.instruction = 0b1110000010010000  # D=D+A
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 2 and cpu.pc == 23 # and DRegister == 1
 
     cpu.instruction = 0b0000001111101000  # @1000
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 24 # and DRegister == -1
 
     cpu.instruction = 0b1110111010010000  # D=-1
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 25 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000001  # D;JGT
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 26 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000010  # D;JEQ
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 27 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000011  # D;JGE
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 28 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000100  # D;JLT
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000101  # D;JNE
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000110  # D;JLE
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
     cpu.instruction = 0b1110001100000111  # D;JMP
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
     cpu.instruction = 0b1110101010010000  # D=0
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000001  # D;JGT
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1002 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000010  # D;JEQ
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000011  # D;JGE
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000100  # D;JLT
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000101  # D;JNE
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1002 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000110  # D;JLE
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
     cpu.instruction = 0b1110001100000111  # D;JMP
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
     cpu.instruction = 0b1110111111010000  # D=1
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000001  # D;JGT
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000010  # D;JEQ
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000011  # D;JGE
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000100  # D;JLT
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000101  # D;JNE
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000110  # D;JLE
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
     cpu.instruction = 0b1110001100000111  # D;JMP
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
     cpu.reset = 1
@@ -298,7 +298,7 @@ def test_cpu(chip=project_05.CPU, cycles_per_instr=1):
 
     cpu.instruction = 0b0111111111111111  # @32767
     cpu.reset = 0
-    for _ in range(cycles_per_instr): cpu.ticktock()
+    cpu.ticktock()
     assert cpu.writeM == 0 and cpu.addressM == 32767 and cpu.pc == 1 # and DRegister == 1
 
 

--- a/test_07.py
+++ b/test_07.py
@@ -8,8 +8,7 @@ import project_05, project_06, project_07
 # TODO: add fine-grained tests for each opcode. These tests ported from nand2tetris provide good 
 # coverage, but they don't isolate problems well for debugging.
 
-
-def test_simple_add(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator):
+def test_simple_add(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator, simulator='codegen'):
     translate = translator()
 
     # Pushes and adds two constants
@@ -19,7 +18,7 @@ def test_simple_add(chip=project_05.Computer, assemble=project_06.assemble, tran
 
     translate.finish()
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
     init_sp(computer)
 
     translate.asm.run(assemble, computer, debug=True)
@@ -28,7 +27,7 @@ def test_simple_add(chip=project_05.Computer, assemble=project_06.assemble, tran
     assert computer.peek(256) == 15
 
 
-def test_stack_ops(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator):
+def test_stack_ops(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator, simulator='codegen'):
     translate = translator()
     
     # Executes a sequence of arithmetic and logical operations
@@ -83,7 +82,7 @@ def test_stack_ops(chip=project_05.Computer, assemble=project_06.assemble, trans
 
     translate.finish()
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     init_sp(computer)
 
@@ -102,7 +101,7 @@ def test_stack_ops(chip=project_05.Computer, assemble=project_06.assemble, trans
     assert computer.peek(265) == -91
 
 
-def test_memory_access_basic(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator):
+def test_memory_access_basic(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator, simulator='codegen'):
     translate = translator()
     
     # Executes pop and push commands using the virtual memory segments.
@@ -134,31 +133,31 @@ def test_memory_access_basic(chip=project_05.Computer, assemble=project_06.assem
 
     translate.finish()
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     init_sp(computer)
-    computer.poke(1, 300)   # base address of the local segment
-    computer.poke(2, 400)   # base address of the argument segment
+    computer.poke(1, 255)   # base address of the local segment
+    computer.poke(2, 247)   # base address of the argument segment
     computer.poke(3, 3000)  # base address of the this segment
     computer.poke(4, 3010)  # base address of the that segment
 
     translate.asm.run(assemble, computer, debug=True)
     
-    # Note for debugging: this tests puts the stack in a funky state. LCL and ARG are _above_ SP, 
-    # which actually makes no sense and as a result the trace is confusing.
-    # For sensible tracing, use ARG = 247 nd LCL = 255
+    # Note: the original test put the stack in a funky state with LCL and ARG are _above_ SP, 
+    # which actually makes no sense and as a result the trace was confusing, so here they're 
+    # set to realistic values.
 
     assert computer.peek(256) == 472
-    assert computer.peek(300) == 10
-    assert computer.peek(401) == 21
-    assert computer.peek(402) == 22
+    assert computer.peek(255) == 10
+    assert computer.peek(248) == 21
+    assert computer.peek(249) == 22
     assert computer.peek(3006) == 36
     assert computer.peek(3012) == 42
     assert computer.peek(3015) == 45
     assert computer.peek(11) == 510
 
 
-def test_memory_access_pointer(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator):
+def test_memory_access_pointer(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator, simulator='codegen'):
     translate = translator()
     
     # Executes pop and push commands using the
@@ -181,7 +180,7 @@ def test_memory_access_pointer(chip=project_05.Computer, assemble=project_06.ass
 
     translate.finish()
     
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     init_sp(computer)
 
@@ -194,7 +193,7 @@ def test_memory_access_pointer(chip=project_05.Computer, assemble=project_06.ass
     assert computer.peek(3046) == 46
     
     
-def test_memory_access_static(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator):
+def test_memory_access_static(chip=project_05.Computer, assemble=project_06.assemble, translator=project_07.Translator, simulator='codegen'):
     translate = translator()
     
     # Executes pop and push commands using the static segment.
@@ -212,7 +211,7 @@ def test_memory_access_static(chip=project_05.Computer, assemble=project_06.asse
 
     translate.finish()
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     init_sp(computer)
 
@@ -234,7 +233,7 @@ def init_sp(computer, address=256):
         "M=D",
     ])
     computer.init_rom(pgm)
-    for i_ in range(len(pgm)):
+    while computer.pc < len(pgm):
         computer.ticktock()
 
     computer.reset = True

--- a/test_08.py
+++ b/test_08.py
@@ -11,7 +11,7 @@ import project_08
 # coverage, but they don't isolate problems well for debugging.
 
 
-def test_basic_loop(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator):
+def test_basic_loop(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator, simulator='codegen'):
     translate = translator()
     
     # Computes the sum 1 + 2 + ... + argument[0] and pushes the 
@@ -34,7 +34,7 @@ def test_basic_loop(chip=project_05.Computer, assemble=project_06.assemble, tran
 
     translate.finish()
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     test_07.init_sp(computer)
     computer.poke(1, 300)
@@ -47,7 +47,7 @@ def test_basic_loop(chip=project_05.Computer, assemble=project_06.assemble, tran
     assert computer.peek(256) == 6
 
 
-def test_fibonacci_series(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator):
+def test_fibonacci_series(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator, simulator='codegen'):
     translate = translator()
     
     # Puts the first argument[0] elements of the Fibonacci series
@@ -96,7 +96,7 @@ def test_fibonacci_series(chip=project_05.Computer, assemble=project_06.assemble
 
     translate.finish()
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     test_07.init_sp(computer)
     computer.poke(1, 300)
@@ -114,7 +114,7 @@ def test_fibonacci_series(chip=project_05.Computer, assemble=project_06.assemble
     assert computer.peek(3005) == 5
 
 
-def test_simple_function(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator):
+def test_simple_function(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator, simulator='codegen'):
     translate = translator()
 
     # Performs a simple calculation and returns the result.
@@ -131,7 +131,7 @@ def test_simple_function(chip=project_05.Computer, assemble=project_06.assemble,
 
     translate.finish()
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     test_07.init_sp(computer, 317)
     computer.poke(1, 317)
@@ -156,7 +156,7 @@ def test_simple_function(chip=project_05.Computer, assemble=project_06.assemble,
     assert computer.peek(310) == 1196
 
 
-def test_nested_call(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator):
+def test_nested_call(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator, simulator='codegen'):
     """Multiple function calls, with and without arguments.
     """
     
@@ -228,7 +228,7 @@ def test_nested_call(chip=project_05.Computer, assemble=project_06.assemble, tra
     translate.finish()
 
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     test_07.init_sp(computer, 261)
     computer.poke(1, 261)
@@ -258,7 +258,7 @@ def test_nested_call(chip=project_05.Computer, assemble=project_06.assemble, tra
     assert computer.peek(6) == 246
 
 
-def test_fibonacci_element(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator):
+def test_fibonacci_element(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator, simulator='codegen'):
     """Sys.init, declared out of sequence, requiring the translator to supply initialization and then 
     call Sys.init. This is finally a fully legitimate VM program, executed in the normal way.
     """
@@ -308,7 +308,7 @@ def test_fibonacci_element(chip=project_05.Computer, assemble=project_06.assembl
     translate.finish()
 
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     # Note: no initialization this time
     
@@ -318,7 +318,7 @@ def test_fibonacci_element(chip=project_05.Computer, assemble=project_06.assembl
     assert computer.peek(261) == 3
 
 
-def test_statics_multiple_files(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator):
+def test_statics_multiple_files(chip=project_05.Computer, assemble=project_06.assemble, translator=project_08.Translator, simulator='codegen'):
     """Tests that different functions, stored in two different classes, manipulate the static 
     segment correctly. 
     
@@ -365,7 +365,7 @@ def test_statics_multiple_files(chip=project_05.Computer, assemble=project_06.as
     translate.finish()
 
 
-    computer = run(chip, simulator='codegen')
+    computer = run(chip, simulator=simulator)
 
     # Note: no initialization this time
 

--- a/test_optimal_02.py
+++ b/test_optimal_02.py
@@ -20,5 +20,8 @@ def test_add16():
 def test_zero16():
     assert gate_count(Zero16)['nands'] == 46  # ?
 
+def test_neg16():
+    assert gate_count(Neg16).get('nands') is None  # No gates; just wiring.
+
 def test_alu():
     assert gate_count(ALU)['nands'] == 560  # ?


### PR DESCRIPTION
An alternative CPU, using an 8-bit ALU working on half of the input on each cycle, and taking two cycles per instruction. This reduces the size of the largest component by 50%, but that gain is offset by some extra logic and latches to keep track of partial results.

This shows that the same architecture _can_ be implemented with fewer gates, but at less than 20% savings in "cost" with exactly 2x worse performance, it.s not exactly a slam dunk.

Note: this chip contains quite a few new 8-bit components, which haven't been implemented as primitives for the codegen simulator. Not only does that make it generate a ton of bit-level logic, it exposes a bug and the resulting code doesn't actually run. Leaving it as is for now, because actually running anything on this CPU is kind of beside the point. You can run small programs using the precise bit-level simulation (e.g. `alt/eight.py --vector examples/FillScreen.asm`).

Thanks to @skillingt for some debugging assistance.