### PR TITLE
Simplified HDL syntax

### DIFF
--- a/alt/eight.py
+++ b/alt/eight.py
@@ -55,34 +55,32 @@ from nand.solutions import solved_06, solved_07
 
 # Project 01:
 
-def mkNot8(inputs, outputs):
+@chip
+def Not8(inputs, outputs):
     in_ = inputs.in_
     for i in range(8):
         outputs.out[i] = Not(in_=in_[i]).out
 
-Not8 = build(mkNot8)
 
-
-def mkAnd8(inputs, outputs):
+@chip
+def And8(inputs, outputs):
     for i in range(8):
         outputs.out[i] = And(a=inputs.a[i], b=inputs.b[i]).out
 
-And8 = build(mkAnd8)
 
-
-def mkMux8(inputs, outputs):
+@chip
+def Mux8(inputs, outputs):
     not_sel = Not(in_=inputs.sel).out
     for i in range(8):
         fromAneg = Nand(a=inputs.a[i], b=not_sel).out
         fromBneg = Nand(a=inputs.b[i], b=inputs.sel).out
         outputs.out[i] = Nand(a=fromAneg, b=fromBneg).out
 
-Mux8 = build(mkMux8)
-
 
 # Project 02:
 
-def mkInc8(inputs, outputs):
+@chip
+def Inc8(inputs, outputs):
     """Note: this is subtly different than Inc16 in that it may or may not actually increment
     the value, under the control of carry_in. This allows the carry to propagate from the low
     word to the high word.
@@ -94,10 +92,9 @@ def mkInc8(inputs, outputs):
         carry = tmp.carry
     outputs.carry_out = carry
 
-Inc8 = build(mkInc8)
 
-
-def mkAdd8(inputs, outputs):
+@chip
+def Add8(inputs, outputs):
     carry = inputs.carry_in
     for i in range(8):
         tmp = FullAdder(a=inputs.a[i], b=inputs.b[i], c=carry)
@@ -105,10 +102,9 @@ def mkAdd8(inputs, outputs):
         carry = tmp.carry
     outputs.carry_out = carry
 
-Add8 = build(mkAdd8)
 
-
-def mkZero8(inputs, outputs):
+@chip
+def Zero8(inputs, outputs):
     in_ = inputs.in_
     outputs.out = And(
         a=And(a=And(a=Not(in_=in_[ 7]).out,
@@ -119,16 +115,15 @@ def mkZero8(inputs, outputs):
                     b=Not(in_=in_[ 2]).out).out,
               b=And(a=Not(in_=in_[ 1]).out,
                     b=Not(in_=in_[ 0]).out).out).out).out
-Zero8 = build(mkZero8)
 
 
-def mkNeg8(inputs, outputs):
+@chip
+def Neg8(inputs, outputs):
     outputs.out = inputs.in_[7]
 
-Neg8 = build(mkNeg8)
 
-
-def mkEightALU(inputs, outputs):
+@chip
+def EightALU(inputs, outputs):
     """Eight-bit ALU, with one addition:
 
     The single low bit carry_in is added along with x and y, and the carry_out from that operation
@@ -166,26 +161,25 @@ def mkEightALU(inputs, outputs):
     outputs.ng = Neg8(in_=out).out
     outputs.carry_out = added.carry_out
 
-EightALU = build(mkEightALU)
-
 
 # Project 03:
 
-def mkRegister8(inputs, outputs):
+@chip
+def Register8(inputs, outputs):
     for i in range(8):
         outputs.out[i] = Bit(in_=inputs.in_[i], load=inputs.load).out
-Register8 = build(mkRegister8)
 
 
-def mkLatch8(inputs, outputs):
+@chip
+def Latch8(inputs, outputs):
     """Just 8 DFFs, for cases where we need to latch a half-word between top and bottom half-cycles.
     """
     for i in range(8):
         outputs.out[i] = DFF(in_=inputs.in_[i]).out
-Latch8 = build(mkLatch8)
 
 
-def mkPC8(inputs, outputs):
+@chip
+def PC8(inputs, outputs):
     """16-bit PC, built from two 8-bit registers and a single Inc8.
 
     On the first half-cycle, the low half-word is incremented but not yet stored.
@@ -226,8 +220,6 @@ def mkPC8(inputs, outputs):
 
     outputs.out = Splice(lo=pc_lo.out, hi=pc_hi.out).out
 
-PC8 = build(mkPC8)
-
 
 # Project 05:
 
@@ -251,7 +243,8 @@ def Not_(x):
     return Not(in_=x).out
 
 
-def mkEightCPU(inputs, outputs):
+@chip
+def EightCPU(inputs, outputs):
     """Implement the 16-bit Hack instruction set using a single 8-bit ALU and a pair of 8-bit
     registers for each architectural register, plus some extra flip-flops to keep track of state
     in between two "half"-cycles.
@@ -323,10 +316,9 @@ def mkEightCPU(inputs, outputs):
     outputs.addressM = a_both_reg                            # Address in data memory (of M) (latched)
     outputs.pc = pc.out                                      # address of next instruction (latched)
 
-EightCPU = build(mkEightCPU)
 
-
-def mkEightComputer(inputs, outputs):
+@chip
+def EightComputer(inputs, outputs):
     reset = inputs.reset
 
     cpu = lazy()
@@ -342,24 +334,22 @@ def mkEightComputer(inputs, outputs):
     outputs.pc = cpu.pc
     outputs.tty_ready = mem.tty_ready
 
-EightComputer = build(mkEightComputer)
-
 
 # 8-bit adapters:
 
-def mkSplice(inputs, outputs):
+@chip
+def Splice(inputs, outputs):
     """Wiring only: assemble two 8-bit signals into a 16-bit signal."""
     for i in range(8):
         outputs.out[i] = inputs.lo[i]
         outputs.out[i+8] = inputs.hi[i]
-Splice = build(mkSplice)
 
-def mkSplit(inputs, outputs):
+@chip
+def Split(inputs, outputs):
     """Wiring only: extract two 8-bit signals from a 16-bit signal."""
     for i in range(8):
         outputs.lo[i] = inputs.in_[i]
         outputs.hi[i] = inputs.in_[i+8]
-Split = build(mkSplit)
 
 
 # Main:

--- a/alt/shift.py
+++ b/alt/shift.py
@@ -27,17 +27,17 @@ from nand.solutions import solved_06
 from nand.solutions import solved_07
 
 
-def mkShiftR16(inputs, outputs):
+@chip
+def ShiftR16(inputs, outputs):
     """Sign-extending right shift."""
 
     for i in range(15):
         outputs.out[i] = inputs.in_[i+1]
     outputs.out[15] = inputs.in_[15]
 
-ShiftR16 = build(mkShiftR16)
 
-
-def mkShiftCPU(inputs, outputs):
+@chip
+def ShiftCPU(inputs, outputs):
     """Implements the Hack architecture, plus a single extra bit of ALU control:
 
     If bit 13 is not set, the result from the ALU is shifted one bit to the right before being
@@ -77,10 +77,9 @@ def mkShiftCPU(inputs, outputs):
     outputs.addressM = a_reg.out             # Address in data memory (of M) (latched)
     outputs.pc = pc.out                      # address of next instruction (latched)
 
-ShiftCPU = build(mkShiftCPU)
 
-
-def mkShiftComputer(inputs, outputs):
+@chip
+def ShiftComputer(inputs, outputs):
     """This is the same as regular Computer, except using ShiftCPU."""
 
     reset = inputs.reset
@@ -97,8 +96,6 @@ def mkShiftComputer(inputs, outputs):
     # Exposing the PC also makes it easy to observe what's happening in a dumb way.
     outputs.pc = cpu.pc
     outputs.tty_ready = mem.tty_ready
-
-ShiftComputer = build(mkShiftComputer)
 
 
 def parse_op(string, symbols={}):

--- a/alt/sp.py
+++ b/alt/sp.py
@@ -46,8 +46,10 @@ from nand.solutions import solved_06
 from nand.solutions import solved_07
 
 
-def mkDec16(inputs, outputs):
-    def mkHalfSub(inputs, outputs):
+@chip
+def Dec16(inputs, outputs):
+    @chip
+    def HalfSub(inputs, outputs):
         """This is the same trick as HalfAdder, with the second input and the output inverted.
         """
 
@@ -61,18 +63,15 @@ def mkDec16(inputs, outputs):
         outputs.sum = Nand(a=not_a_or_not_b, b=a_or_b).out
         outputs.neg_carry = Not(in_=a_or_b).out
 
-    HalfSub = build(mkHalfSub)
-
     neg_carry = outputs.out[0] = Not(in_=inputs.in_[0]).out
     for i in range(1, 16):
         sub = HalfSub(a=inputs.in_[i], neg_b=neg_carry)
         outputs.out[i] = sub.sum
         neg_carry = sub.neg_carry
 
-Dec16 = build(mkDec16)
 
-
-def mkSPCPU(inputs, outputs):
+@chip
+def SPCPU(inputs, outputs):
     """Implements the Hack architecture, plus two extra instructions:
 
     Pop to register:
@@ -172,10 +171,9 @@ def mkSPCPU(inputs, outputs):
     # expose SP for debugging purposes (since it's no longer found in the RAM)
     outputs.sp = sp_reg.out
 
-SPCPU = build(mkSPCPU)
 
-
-def mkSPComputer(inputs, outputs):
+@chip
+def SPComputer(inputs, outputs):
     """This is the same as regular Computer, except using SPCPU, and exposing `sp` as an output so that
     it can be inspected for tests and debugging.
     """
@@ -195,8 +193,6 @@ def mkSPComputer(inputs, outputs):
     outputs.pc = cpu.pc
     outputs.sp = cpu.sp
     outputs.tty_ready = mem.tty_ready
-
-SPComputer = build(mkSPComputer)
 
 
 def parse_op(string, symbols={}):
@@ -260,7 +256,7 @@ class Translator(solved_07.Translator):
         self.asm.instr("SP++=D")
 
     def _pop_d(self):
-        # TODO: no need for this as soon as everything's switched to use SP++ directly?
+        # TODO: no need for this as soon as everything's switched to use --SP directly?
         self.asm.instr("D=--SP")
 
     def _binary(self, opcode, op):

--- a/alt/test_eight.py
+++ b/alt/test_eight.py
@@ -289,7 +289,8 @@ def test_alu_chained():
     """Test sequential application of the 8-bit ALU by connecting two separate ALUs, with the
     carry bit wired between them.
     """
-    def mkChainedALU(inputs, outputs):
+    @chip
+    def ChainedALU(inputs, outputs):
         x_split = Split(in_=inputs.x)
         y_split = Split(in_=inputs.y)
         alu_lo = EightALU(x=x_split.lo, y=y_split.lo,
@@ -301,7 +302,6 @@ def test_alu_chained():
         outputs.out = Splice(lo=alu_lo.out, hi=alu_hi.out).out
         outputs.zr = And(a=alu_lo.zr, b=alu_hi.zr).out
         outputs.ng = alu_hi.ng
-    ChainedALU = build(mkChainedALU)
 
     test_02.test_alu(ChainedALU)
 

--- a/alt/threaded.py
+++ b/alt/threaded.py
@@ -40,7 +40,8 @@ from nand.solutions import solved_07
 # of many-input Nands.)
 # Note: this simplifies to Zero16, if one of the inputs is 0, so maybe should just implement this
 # in project_02 instead.
-def mkEq16(inputs, outputs):
+@chip
+def Eq16(inputs, outputs):
     a = inputs.a
     b = inputs.b
 
@@ -61,18 +62,17 @@ def mkEq16(inputs, outputs):
                           b=Not(in_=Xor(a=a[ 2], b=b[ 2]).out).out).out,
                     b=And(a=Not(in_=Xor(a=a[ 1], b=b[ 1]).out).out,
                           b=Not(in_=Xor(a=a[ 0], b=b[ 0]).out).out).out).out).out).out
-Eq16 = build(mkEq16)
 
 
-def mkMask15(inputs, outputs):
+@chip
+def Mask15(inputs, outputs):
     for i in range(15):
         outputs.out[i] = inputs.in_[i]
     outputs.out[15] = Not(in_=1).out  # HACK: syntax not working for output bit, apparently
 
-Mask15 = build(mkMask15)
 
-
-def mkThreadedCPU(inputs, outputs):
+@chip
+def ThreadedCPU(inputs, outputs):
     """Backwards-compatible with the Hack CPU, with two additional instructions and a new register
     storing a return address written by CALL and read by RTN.
 
@@ -158,10 +158,9 @@ def mkThreadedCPU(inputs, outputs):
     outputs.addressM = a_reg.out             # Address in data memory (of M) (latched)
     outputs.pc = pc.out                      # address of next instruction (latched)
 
-ThreadedCPU = build(mkThreadedCPU)
 
-
-def mkThreadedComputer(inputs, outputs):
+@chip
+def ThreadedComputer(inputs, outputs):
     reset = inputs.reset
 
     cpu = lazy()
@@ -176,8 +175,6 @@ def mkThreadedComputer(inputs, outputs):
     # Exposing the PC also makes it easy to observe what's happening in a dumb way.
     outputs.pc = cpu.pc
     outputs.tty_ready = mem.tty_ready
-
-ThreadedComputer = build(mkThreadedComputer)
 
 
 def parse_op(string, symbols={}):

--- a/nand/__init__.py
+++ b/nand/__init__.py
@@ -7,4 +7,4 @@ implemented.
 """
 
 from nand.vector import unsigned
-from nand.syntax import Nand, DFF, ROM, RAM, Input, Output, lazy, clock, build, run, gate_count
+from nand.syntax import Nand, DFF, ROM, RAM, Input, Output, chip, lazy, clock, run, gate_count

--- a/nand/solutions/solved_02.py
+++ b/nand/solutions/solved_02.py
@@ -9,10 +9,11 @@ from nand import *
 from nand.solutions.solved_01 import And, And16, Or, Mux16, Not, Not16, Xor
 
 
-def mkHalfAdder(inputs, outputs):
+@chip
+def HalfAdder(inputs, outputs):
     a = inputs.a
     b = inputs.b
-    
+
     nand = Nand(a=a, b=b).out
 
     # Xor(a, b):
@@ -23,28 +24,26 @@ def mkHalfAdder(inputs, outputs):
     # And(a, b):
     outputs.carry = Not(in_=nand).out
 
-HalfAdder = build(mkHalfAdder)
 
-
-def mkFullAdder(inputs, outputs):
-    def mkHalfAdderNot(inputs, outputs):
+@chip
+def FullAdder(inputs, outputs):
+    @chip
+    def HalfAdderNot(inputs, outputs):
         """Half-adder with one less gate by exposing the opposite of carry."""
         nand = Nand(a=inputs.a, b=inputs.b).out
         nandANand = Nand(a=inputs.a, b=nand).out
         nandBNand = Nand(a=nand, b=inputs.b).out
         outputs.sum = Nand(a=nandANand, b=nandBNand).out
         outputs.not_carry = nand
-    HalfAdderNot = build(mkHalfAdderNot)
 
     ab = HalfAdderNot(a=inputs.a, b=inputs.b)
     abc = HalfAdderNot(a=ab.sum, b=inputs.c)
     outputs.carry = Nand(a=ab.not_carry, b=abc.not_carry).out
     outputs.sum = abc.sum
 
-FullAdder = build(mkFullAdder)
 
-
-def mkInc16(inputs, outputs):
+@chip
+def Inc16(inputs, outputs):
     # Don't even need a whole HalfAdder for the low bit:
     outputs.out[0] = Not(in_=inputs.in_[0]).out
     carry = inputs.in_[0]
@@ -53,10 +52,9 @@ def mkInc16(inputs, outputs):
         outputs.out[i] = tmp.sum
         carry = tmp.carry
 
-Inc16 = build(mkInc16)
 
-
-def mkAdd16(inputs, outputs):
+@chip
+def Add16(inputs, outputs):
     a = HalfAdder(a=inputs.a[0], b=inputs.b[0])
     outputs.out[0] = a.sum
     for i in range(1, 16):
@@ -64,10 +62,9 @@ def mkAdd16(inputs, outputs):
         outputs.out[i] = tmp.sum
         a = tmp
 
-Add16 = build(mkAdd16)
 
-
-def mkZero16(inputs, outputs):
+@chip
+def Zero16(inputs, outputs):
     in_ = inputs.in_
     outputs.out = And(
         a=And(a=And(a=And(a=Not(in_=in_[15]).out,
@@ -86,42 +83,39 @@ def mkZero16(inputs, outputs):
                           b=Not(in_=in_[ 2]).out).out,
                     b=And(a=Not(in_=in_[ 1]).out,
                           b=Not(in_=in_[ 0]).out).out).out).out).out
-Zero16 = build(mkZero16)
 
 
-def mkNeg16(inputs, outputs):
+@chip
+def Neg16(inputs, outputs):
     outputs.out = inputs.in_[15]
 
-Neg16 = build(mkNeg16)
 
-
-def mkALU(inputs, outputs):
+@chip
+def ALU(inputs, outputs):
     x = inputs.x
     y = inputs.y
-    
+
     zx = inputs.zx
     nx = inputs.nx
     zy = inputs.zy
     ny = inputs.ny
     f  = inputs.f
     no = inputs.no
-    
+
     x_zeroed = Mux16(a=x, b=0, sel=zx).out
     y_zeroed = Mux16(a=y, b=0, sel=zy).out
 
     x_inverted = Mux16(a=x_zeroed, b=Not16(in_=x_zeroed).out, sel=nx).out
     y_inverted = Mux16(a=y_zeroed, b=Not16(in_=y_zeroed).out, sel=ny).out
-    
+
     anded = And16(a=x_inverted, b=y_inverted).out
     added = Add16(a=x_inverted, b=y_inverted).out
-    
+
     result = Mux16(a=anded, b=added, sel=f).out
     result_inverted = Not16(in_=result).out
-    
+
     out = Mux16(a=result, b=result_inverted, sel=no).out
-    
+
     outputs.out = out
     outputs.zr = Zero16(in_=out).out
     outputs.ng = Neg16(in_=out).out
-    
-ALU = build(mkALU)

--- a/nand/solutions/solved_05.py
+++ b/nand/solutions/solved_05.py
@@ -5,26 +5,27 @@ If you want to solve them on your own, stop reading now!
 """
 
 from nand.component import Const
-from nand import RAM, ROM, Input, Output, build, lazy
+from nand import RAM, ROM, Input, Output, chip, lazy
 from nand.solutions.solved_01 import *
 from nand.solutions.solved_02 import *
 from nand.solutions.solved_03 import *
 
 
-def mkMemorySystem(inputs, outputs):
+@chip
+def MemorySystem(inputs, outputs):
     in_ = inputs.in_
     load = inputs.load
     address = inputs.address
 
-    def mkShift13(inputs, outputs):
+    @chip
+    def Shift13(inputs, outputs):
         outputs.out[0] = inputs.in_[13]
         outputs.out[1] = inputs.in_[14]
-    Shift13 = build(mkShift13)
 
-    def mkMask14(inputs, outputs):
+    @chip
+    def Mask14(inputs, outputs):
         for i in range(14):
             outputs.out[i] = inputs.in_[i]
-    Mask14 = build(mkMask14)
 
     bank = Shift13(in_=address).out
     load_bank = DMux4Way(in_=load, sel=bank)
@@ -48,10 +49,9 @@ def mkMemorySystem(inputs, outputs):
     # gets the job done.
     outputs.tty_ready = tty.ready
 
-MemorySystem = build(mkMemorySystem)
 
-
-def mkCPU(inputs, outputs):
+@chip
+def CPU(inputs, outputs):
     inM = inputs.inM                 # M value input (M = contents of RAM[A])
     instruction = inputs.instruction # Instruction for execution
     reset = inputs.reset             # Signals whether to re-start the current
@@ -81,10 +81,9 @@ def mkCPU(inputs, outputs):
     outputs.addressM = a_reg.out             # Address in data memory (of M) (latched)
     outputs.pc = pc.out                      # address of next instruction (latched)
 
-CPU = build(mkCPU)
 
-
-def mkComputer(inputs, outputs):
+@chip
+def Computer(inputs, outputs):
     reset = inputs.reset
 
     cpu = lazy()
@@ -109,5 +108,3 @@ def mkComputer(inputs, outputs):
     # would create.
     # keyboard = inputs.keyboard
     # outputs.tty = mem.tty
-
-Computer = build(mkComputer)

--- a/project_01.py
+++ b/project_01.py
@@ -2,13 +2,13 @@
 #
 # See https://www.nand2tetris.org/project01
 
-from nand import Nand, build
+from nand import Nand, chip
 
 # SOLVERS: remove this import to get started
 from nand.solutions import solved_01
 
-
-def mkNot(inputs, outputs):
+@chip
+def Not(inputs, outputs):
     in_ = inputs.in_
 
     # SOLVERS: replace this with a Nand
@@ -16,10 +16,9 @@ def mkNot(inputs, outputs):
 
     outputs.out = n1.out
 
-Not = build(mkNot)
 
-
-def mkOr(inputs, outputs):
+@chip
+def Or(inputs, outputs):
     a = inputs.a
     b = inputs.b
 
@@ -28,10 +27,9 @@ def mkOr(inputs, outputs):
 
     outputs.out = n1.out
 
-Or = build(mkOr)
 
-
-def mkAnd(inputs, outputs):
+@chip
+def And(inputs, outputs):
     a = inputs.a
     b = inputs.b
 
@@ -40,10 +38,9 @@ def mkAnd(inputs, outputs):
 
     outputs.out = n1.out
 
-And = build(mkAnd)
 
-
-def mkXor(inputs, outputs):
+@chip
+def Xor(inputs, outputs):
     a = inputs.a
     b = inputs.b
 
@@ -52,10 +49,9 @@ def mkXor(inputs, outputs):
 
     outputs.out = n1.out
 
-Xor = build(mkXor)
 
-
-def mkMux(inputs, outputs):
+@chip
+def Mux(inputs, outputs):
     a = inputs.a
     b = inputs.b
     sel = inputs.sel
@@ -65,10 +61,9 @@ def mkMux(inputs, outputs):
 
     outputs.out = n1.out
 
-Mux = build(mkMux)
 
-
-def mkDMux(inputs, outputs):
+@chip
+def DMux(inputs, outputs):
     in_ = inputs.in_
     sel = inputs.sel
 
@@ -78,10 +73,9 @@ def mkDMux(inputs, outputs):
     outputs.a = n1.a
     outputs.b = n1.b
 
-DMux = build(mkDMux)
 
-
-def mkDMux4Way(inputs, outputs):
+@chip
+def DMux4Way(inputs, outputs):
     in_ = inputs.in_
     sel = inputs.sel
 
@@ -94,10 +88,9 @@ def mkDMux4Way(inputs, outputs):
     outputs.c = n1.c
     outputs.d = n1.d
 
-DMux4Way = build(mkDMux4Way)
 
-
-def mkDMux8Way(inputs, outputs):
+@chip
+def DMux8Way(inputs, outputs):
     in_ = inputs.in_
     sel = inputs.sel
 
@@ -113,22 +106,20 @@ def mkDMux8Way(inputs, outputs):
     outputs.g = n1.g
     outputs.h = n1.h
 
-DMux8Way = build(mkDMux8Way)
 
-
-def mkNot16(inputs, outputs):
+@chip
+def Not16(inputs, outputs):
     in_ = inputs.in_
 
     # SOLVERS: replace this with one or more Nands and/or components defined above
-    # Hint: use outputs.out[0]... to connect each bit of the output
+    # Hint: use outputs.out[0] = ... in_[0] ..., etc. to connect each bit of the output
     n1 = solved_01.Not16(in_=in_)
 
     outputs.out = n1.out
 
-Not16 = build(mkNot16)
 
-
-def mkAnd16(inputs, outputs):
+@chip
+def And16(inputs, outputs):
     a = inputs.a
     b = inputs.b
 
@@ -137,10 +128,9 @@ def mkAnd16(inputs, outputs):
 
     outputs.out = n1.out
 
-And16 = build(mkAnd16)
 
-
-def mkMux16(inputs, outputs):
+@chip
+def Mux16(inputs, outputs):
     a = inputs.a
     b = inputs.b
     sel = inputs.sel
@@ -150,10 +140,9 @@ def mkMux16(inputs, outputs):
 
     outputs.out = n1.out
 
-Mux16 = build(mkMux16)
 
-
-def mkMux4Way16(inputs, outputs):
+@chip
+def Mux4Way16(inputs, outputs):
     a = inputs.a
     b = inputs.b
     c = inputs.c
@@ -165,10 +154,9 @@ def mkMux4Way16(inputs, outputs):
 
     outputs.out = n1.out
 
-Mux4Way16 = build(mkMux4Way16)
 
-
-def mkMux8Way16(inputs, outputs):
+@chip
+def Mux8Way16(inputs, outputs):
     a = inputs.a
     b = inputs.b
     c = inputs.c
@@ -183,5 +171,3 @@ def mkMux8Way16(inputs, outputs):
     n1 = solved_01.Mux8Way16(a=a, b=b, c=c, d=d, e=e, f=f, g=g, h=h, sel=sel)
 
     outputs.out = n1.out
-
-Mux8Way16 = build(mkMux8Way16)

--- a/project_02.py
+++ b/project_02.py
@@ -2,14 +2,15 @@
 #
 # See https://www.nand2tetris.org/project02
 
-from nand import Nand, build
+from nand import Nand, chip
 from project_01 import And, And16, Or, Mux16, Not, Not16, Xor
 
 # SOLVERS: remove this import to get started
 from nand.solutions import solved_02
 
 
-def mkHalfAdder(inputs, outputs):
+@chip
+def HalfAdder(inputs, outputs):
     a = inputs.a
     b = inputs.b
 
@@ -19,10 +20,9 @@ def mkHalfAdder(inputs, outputs):
     outputs.sum = n1.sum
     outputs.carry = n1.carry
 
-HalfAdder = build(mkHalfAdder)
 
-
-def mkFullAdder(inputs, outputs):
+@chip
+def FullAdder(inputs, outputs):
     a = inputs.a
     b = inputs.b
     c = inputs.c
@@ -33,10 +33,9 @@ def mkFullAdder(inputs, outputs):
     outputs.sum = n1.sum
     outputs.carry = n1.carry
 
-FullAdder = build(mkFullAdder)
 
-
-def mkInc16(inputs, outputs):
+@chip
+def Inc16(inputs, outputs):
     """Add one to a single 16-bit input, ignoring overflow."""
 
     in_ = inputs.in_
@@ -46,10 +45,9 @@ def mkInc16(inputs, outputs):
 
     outputs.out = n1.out
 
-Inc16 = build(mkInc16)
 
-
-def mkAdd16(inputs, outputs):
+@chip
+def Add16(inputs, outputs):
     """Add two 16-bit inputs, ignoring overflow."""
 
     a = inputs.a
@@ -60,10 +58,9 @@ def mkAdd16(inputs, outputs):
 
     outputs.out = n1.out
 
-Add16 = build(mkAdd16)
 
-
-def mkZero16(inputs, outputs):
+@chip
+def Zero16(inputs, outputs):
     """Test whether a single 16-bit input has the value 0."""
 
     in_ = inputs.in_
@@ -73,10 +70,9 @@ def mkZero16(inputs, outputs):
 
     outputs.out = n1.out
 
-Zero16 = build(mkZero16)
 
-
-def mkNeg16(inputs, outputs):
+@chip
+def Neg16(inputs, outputs):
     """Test whether a single 16-bit input is negative."""
 
     in_ = inputs.in_
@@ -86,10 +82,9 @@ def mkNeg16(inputs, outputs):
 
     outputs.out = n1.out
 
-Neg16 = build(mkNeg16)
 
-
-def mkALU(inputs, outputs):
+@chip
+def ALU(inputs, outputs):
     """Combine two 16-bit inputs according to six control bits, producing a 16-bit result and two
     condition codes.
     """
@@ -110,5 +105,3 @@ def mkALU(inputs, outputs):
     outputs.out = n1.out  # the resulting value
     outputs.zr = n1.zr    # is the output equal to 0?
     outputs.ng = n1.ng    # is the output negative?
-
-ALU = build(mkALU)

--- a/project_03.py
+++ b/project_03.py
@@ -2,7 +2,7 @@
 #
 # See https://www.nand2tetris.org/project03
 
-from nand import build, clock
+from nand import chip, clock
 
 from project_01 import *
 from project_02 import *
@@ -11,7 +11,8 @@ from project_02 import *
 from nand.solutions import solved_03
 
 
-def mkMyDFF(inputs, outputs):
+@chip
+def MyDFF(inputs, outputs):
     # Note: provided as a primitive in the Nand to Tetris simulator, but implementing it
     # from scratch is fun.
 
@@ -24,10 +25,9 @@ def mkMyDFF(inputs, outputs):
 
     outputs.out = n1.out
 
-MyDFF = build(mkMyDFF)
 
-
-def mkBit(inputs, outputs):
+@chip
+def Bit(inputs, outputs):
     # OK to use the primitive DFF here, for the most efficient result.
 
     in_ = inputs.in_
@@ -38,10 +38,9 @@ def mkBit(inputs, outputs):
 
     outputs.out = n1.out
 
-Bit = build(mkBit)
 
-
-def mkRegister(inputs, outputs):
+@chip
+def Register(inputs, outputs):
     in_ = inputs.in_
     load = inputs.load
 
@@ -50,10 +49,9 @@ def mkRegister(inputs, outputs):
 
     outputs.out = n1.out
 
-Register = build(mkRegister)
 
-
-def mkRAM8(inputs, outputs):
+@chip
+def RAM8(inputs, outputs):
     in_ = inputs.in_
     load = inputs.load
     address = inputs.address
@@ -63,10 +61,9 @@ def mkRAM8(inputs, outputs):
 
     outputs.out = n1.out
 
-RAM8 = build(mkRAM8)
 
-
-def mkRAM64(inputs, outputs):
+@chip
+def RAM64(inputs, outputs):
     in_ = inputs.in_
     load = inputs.load
     address = inputs.address
@@ -76,10 +73,9 @@ def mkRAM64(inputs, outputs):
 
     outputs.out = n1.out
 
-RAM64 = build(mkRAM64)
 
-
-def mkRAM512(inputs, outputs):
+@chip
+def RAM512(inputs, outputs):
     in_ = inputs.in_
     load = inputs.load
     address = inputs.address
@@ -89,15 +85,14 @@ def mkRAM512(inputs, outputs):
 
     outputs.out = n1.out
 
-RAM512 = build(mkRAM512)
-
 
 # SOLVERS: This has gotten repetitive by now, so just use the provided RAM4K and RAM16K
 RAM4K = solved_03.RAM4K
 RAM16K = solved_03.RAM16K
 
 
-def mkPC(inputs, outputs):
+@chip
+def PC(inputs, outputs):
     in_ = inputs.in_
     load = inputs.load
     inc = inputs.inc
@@ -107,5 +102,3 @@ def mkPC(inputs, outputs):
     n1 = solved_03.PC(in_=in_, load=load, inc=inc, reset=reset)
 
     outputs.out = n1.out
-
-PC = build(mkPC)

--- a/project_05.py
+++ b/project_05.py
@@ -2,7 +2,7 @@
 #
 # See https://www.nand2tetris.org/project05
 
-from nand import RAM, ROM, Input, build, lazy
+from nand import RAM, ROM, Input, chip, lazy
 from project_01 import *
 from project_02 import *
 from project_03 import *
@@ -25,7 +25,8 @@ from nand.solutions import solved_05
 # have that if it was your job to debug the OS code for writing to the screen (and it
 # will be — see project 12.)
 
-def mkMemorySystem(inputs, outputs):
+@chip
+def MemorySystem(inputs, outputs):
     in_ = inputs.in_
     load = inputs.load
     address = inputs.address
@@ -37,10 +38,9 @@ def mkMemorySystem(inputs, outputs):
     outputs.out = n1.out
     outputs.tty_ready = n1.tty_ready  # Wire this up to your Output component's "ready" signal.
 
-MemorySystem = build(mkMemorySystem)
 
-
-def mkCPU(inputs, outputs):
+@chip
+def CPU(inputs, outputs):
     inM = inputs.inM                 # M value input (M = contents of RAM[A])
     instruction = inputs.instruction # Instruction for execution
     reset = inputs.reset             # Signals whether to re-start the current
@@ -55,7 +55,6 @@ def mkCPU(inputs, outputs):
     outputs.addressM = n1.addressM   # Address in data memory (of M) (latched)
     outputs.pc = n1.pc               # address of next instruction (latched)
 
-CPU = build(mkCPU)
 
 
 # Note: there are a couple of required outputs for Computer, which aren't seen in
@@ -70,7 +69,8 @@ CPU = build(mkCPU)
 #    but it's the only available output so there you go.
 
 
-def mkComputer(inputs, outputs):
+@chip
+def Computer(inputs, outputs):
     reset = inputs.reset
 
     # SOLVERS: replace this with one or more Nands and/or components defined above
@@ -78,5 +78,3 @@ def mkComputer(inputs, outputs):
 
     outputs.pc = n1.pc
     outputs.tty_ready = n1.tty_ready  # Note: wire this the output from MemorySystem
-
-Computer = build(mkComputer)


### PR DESCRIPTION
Add a simple "function decorator", `chip`, so you don't have to write and read both a function and a wrapper around it.

This eliminates the magical name convention in favor of a magical transformation of the function.

You can now write this:

```python
@chip
def Foo(inputs, outputs):
  outputs.out = ...
```

Where before it looked like this:

```python
def mkFoo(inputs, outputs):
  outputs.out = ...
Foo = build(mkFoo)
```

