### PR TITLE
Implement MemorySystem with one-cycle latency

### DIFF
--- a/alt/README.md
+++ b/alt/README.md
@@ -34,11 +34,11 @@ replaces certain function calls with lower-overhead "reduced" alternatives.
 
 | Location                         | Nands        | ROM size       | Cycles per frame | Cycles for init    |
 |----------------------------------|-------------:|---------------:|-----------------:|-------------------:|
-| project_0*.py                    | 1,262        |         25,700 |           41,450 |            129,200 |
-| [alt/sp.py](sp.py)               | 1,844 (+46%) |  14,150 (-45%) |    27,440 (-34%) |      76,240 (-41%) |
-| [alt/threaded.py](threaded.py)   | 1,549 (+23%) |   8,100 (-68%) |    49,600 (+20%) |     173,750 (+34%) |
-| [alt/shift.py](shift.py)         | 1,311 (+4%)  |   26,050 (+1%) |    19,800 (-52%) |             _same_ |
-| [alt/eight.py](eight.py)         | 1,032 (-18%) |        _same_  |            +100% |              +100% |
+| project_0*.py                    | 1,314        |         25,700 |           41,450 |            129,200 |
+| [alt/sp.py](sp.py)               |     ? (+46%) |  14,150 (-45%) |    27,440 (-34%) |      76,240 (-41%) |
+| [alt/threaded.py](threaded.py)   |     ? (+23%) |   8,100 (-68%) |    49,600 (+20%) |     173,750 (+34%) |
+| [alt/shift.py](shift.py)         |     ? (+4%)  |   26,050 (+1%) |    19,800 (-52%) |             _same_ |
+| [alt/eight.py](eight.py)         |     ? (-18%) |        _same_  |            +100% |              +100% |
 | [alt/lazy.py](lazy.py)           | _same_       |   23,650 (-8%) |    37,300 (-10%) |     111,000 (-14%) |
 | [alt/reg.py](reg.py)             | _same_       |  20,900 (-19%) |    19,150 (-54%) |      59,000 (-54%) |
 | [alt/reduce.py](reduce.py)       | _same_       | 27,350 (+6.5%) |    20,300 (-51%) |             _same_ |

--- a/nand/codegen.py
+++ b/nand/codegen.py
@@ -435,19 +435,18 @@ def generate_python(ic, inline=True, prefix_super=False, cython=False):
                 l(5,   f"self.{output_name(comp)} = {src_many(comp, 'in_')}")
             any_state = True
         elif comp.label == "MemorySystem":
-            # Note: the source of address better not be a big computation. At the moment it's always
-            # register A (so, saved in self)
-            address_expr = src_many(comp, 'address', 14)
+            # Note: we also write to the latched address, because that's what's most useful
             in_name = f"_{all_comps.index(comp)}_in"
             l(4, f"if {src_one(comp, 'load')}:")
             l(5,   f"{in_name} = {src_many(comp, 'in_')}")
-            l(5,   f"if 0 <= {address_expr} < 0x4000:")
-            l(6,     f"self._ram[{address_expr}] = {in_name}")
-            l(5,   f"elif 0x4000 <= {address_expr} < 0x6000:")
-            l(6,     f"self._screen[{address_expr} & 0x1fff] = {in_name}")
-            l(5,   f"elif {address_expr} == 0x6000:")
+            l(5,   f"if 0 <= self._latched_address < 0x4000:")
+            l(6,     f"self._ram[self._latched_address] = {in_name}")
+            l(5,   f"elif 0x4000 <= self._latched_address < 0x6000:")
+            l(6,     f"self._screen[self._latched_address & 0x1fff] = {in_name}")
+            l(5,   f"elif self._latched_address == 0x6000:")
             l(6,     f"self._tty = {in_name}")
             l(6,     f"self._tty_ready = {in_name} != 0")
+            address_expr = src_many(comp, 'address', 14)
             l(4, f"self._latched_address = {address_expr}")
             any_state = True
         elif isinstance(comp, (Const, ROM)):

--- a/nand/component.py
+++ b/nand/component.py
@@ -97,15 +97,19 @@ class ROM(Component):
 
 class RAM(Component):
     """Memory containing 2^n words which can be read and written by the chip, with fixed
-    read latency of one cycle. Throughput is one write and/or read per cycle, but since there's
-    only one address input, you can't do unrelated read/write ops (specifically, a read always
-    reads the value written by the previous write, which probably isn't useful.)
-
-    To store a value, set all three inputs. The update value becomes available
-    on the next cycle.
+    latency of one cycle for both reads and writes. Throughput is one write and/or read per cycle.
 
     To read a previously set value, set `address`, wait one cycle, and then
     inspect `out`. This delay is meant to model the inherent trade-off of moving storage off-chip.
+
+    To store a value, set `address` and `load`, wait one cycle, set `in_`, then wait again. The
+    value provided in the second cycle is stored at the address provided in the first. That probably
+    seems perverse. It turns out to be what you need to usefully read and write in the same cycle.
+
+    For example, to pop from a stack that grows upward:
+      A=0     // location of the stack pointer
+      AM=M-1  // decrement the stack pointer in memory (read and write address 0)
+      D=M     // read from the
     """
     def __init__(self, address_bits):
         Component.__init__(self)

--- a/nand/component.py
+++ b/nand/component.py
@@ -78,6 +78,10 @@ class ROM(Component):
 
     The entire contents can be over-written from outside when initializing the assembled chip
     (so, really it's an EEPROM.)
+
+    Note: this component imposes no timing constraint; you can supply `address` and read the
+    corresponding value from `out` without waiting for the next cycle. Not sure how realistic
+    that is.
     """
 
     def __init__(self, address_bits):
@@ -92,7 +96,16 @@ class ROM(Component):
 
 
 class RAM(Component):
-    """Memory containing 2^n words which can be read and written by the chip.
+    """Memory containing 2^n words which can be read and written by the chip, with fixed
+    read latency of one cycle. Throughput is one write and/or read per cycle, but since there's
+    only one address input, you can't do unrelated read/write ops (specifically, a read always
+    reads the value written by the previous write, which probably isn't useful.)
+
+    To store a value, set all three inputs. The update value becomes available
+    on the next cycle.
+
+    To read a previously set value, set `address`, wait one cycle, and then
+    inspect `out`. This delay is meant to model the inherent trade-off of moving storage off-chip.
     """
     def __init__(self, address_bits):
         Component.__init__(self)

--- a/nand/integration.py
+++ b/nand/integration.py
@@ -194,9 +194,7 @@ class IC:
                 return True
             elif isinstance(from_comp, IC) and from_comp.label == "Register":
                 return True
-            elif isinstance(to_comp, IC) and to_comp.label == "MemorySystem" and input_name != "address":
-                # This is the tricky case. The address is needed to supply the correct output, but
-                # other inputs (in_ and load) are only used at update time.
+            elif isinstance(from_comp, IC) and from_comp.label == "MemorySystem":
                 return True
             else:
                 return False

--- a/nand/solutions/solved_03.py
+++ b/nand/solutions/solved_03.py
@@ -44,6 +44,11 @@ def Register(inputs, outputs):
         outputs.out[i] = Bit(in_=inputs.in_[i], load=inputs.load).out
 
 
+# Note: these RAMs don't latch the address and delay delivery of the output until the following
+# cycle, as the "real" RAM is allowed/required to do. That's ok, because implementing RAM from
+# DFFs like this is an unrealistic exercise anyway. The tests for this project allow either
+# behavior.
+
 @chip
 def RAM8(inputs, outputs):
     load = DMux8Way(in_=inputs.load, sel=inputs.address)

--- a/nand/solutions/solved_05.py
+++ b/nand/solutions/solved_05.py
@@ -77,10 +77,13 @@ def CPU(inputs, outputs):
     alu.set(ALU(x=d_reg.out, y=Mux16(a=a_reg.out, b=inM, sel=a).out,
                 zx=c5, nx=c4, zy=c3, ny=c2, f=c1, no=c0))
 
+    # Tricky: the memory now requires the address to be presented one-cycle ahead, so "pipeline"
+    # it from the instruction if it is being written to A in this cycle.
+    addr = Mux16(a=instruction, b=a_reg.out, sel=i).out
 
     outputs.outM = alu.out                   # M value output
     outputs.writeM = And(a=dm, b=i).out      # Write to M?
-    outputs.addressM = a_reg.out             # Address in data memory (of M) (latched)
+    outputs.addressM = addr                  # Address in data memory (of M) (latched)
     outputs.pc = pc.out                      # address of next instruction (latched)
 
 

--- a/nand/solutions/solved_05.py
+++ b/nand/solutions/solved_05.py
@@ -87,7 +87,7 @@ def CPU(inputs, outputs):
 
     # Don't write to memory if a reset is happening, mostly because there's a test from the
     # original materials that checks. Note: writes to A and D are not suppressed; I suppose
-    # one could argue that it doesn't matter becuse the program shouldn't assume they're zero?
+    # one could argue that it doesn't matter because the program shouldn't assume they're zero?
     write = And(a=And(
                 a=dm,
                 b=i).out,

--- a/nand/solutions/solved_05.py
+++ b/nand/solutions/solved_05.py
@@ -85,10 +85,18 @@ def CPU(inputs, outputs):
     # it from the instruction/alu which is being written to A in this cycle.
     addr = Mux16(a=a_reg.out, b=a_in, sel=a_load).out
 
-    outputs.outM = alu.out                   # M value output
-    outputs.writeM = And(a=dm, b=i).out      # Write to M?
-    outputs.addressM = addr                  # Address in data memory (of M) (latched)
-    outputs.pc = pc.out                      # address of next instruction (latched)
+    # Don't write to memory if a reset is happening, mostly because there's a test from the
+    # original materials that checks. Note: writes to A and D are not suppressed; I suppose
+    # one could argue that it doesn't matter becuse the program shouldn't assume they're zero?
+    write = And(a=And(
+                a=dm,
+                b=i).out,
+                b=Not(in_=reset).out).out
+
+    outputs.outM = alu.out    # M value output
+    outputs.writeM = write    # Write to M?
+    outputs.addressM = addr   # Address in data memory (of M)
+    outputs.pc = pc.out       # address of next instruction (latched)
 
 
 @chip

--- a/nand/solutions/solved_05.py
+++ b/nand/solutions/solved_05.py
@@ -42,6 +42,8 @@ def MemorySystem(inputs, outputs):
     keyboard = Input()
     tty = Output(in_=in_, load=load_bank.d)
 
+    # Note: this is mapping keyboard/input to _all_ high addresses, which definitely seems like
+    # cheating.
     outputs.out = Mux4Way16(a=ram.out, b=ram.out, c=screen.out, d=keyboard.out, sel=bank).out
 
     # Tricky: need to expose some "output" from the Output component in order for the component

--- a/nand/test_codegen.py
+++ b/nand/test_codegen.py
@@ -180,7 +180,7 @@ def test_alu():
 def test_pc():
     pc = run(project_03.PC.constr())
 
-    # HACK: copied verbatim from test_02
+    # HACK: copied verbatim from test_03
 
     pc.in_ = 0; pc.reset = 0; pc.load = 0; pc.inc = 0
     pc.tick(); pc.tock()
@@ -242,223 +242,227 @@ def test_pc():
     assert pc.out == 0
 
 
-def test_cpu():
-    cpu = run(project_05.CPU.constr())
+# FIXME: what was/is the purpose of re-iterating these tests here? If this is testing something,
+# it could invoke test_05.test_cpu() with some different arguments. It doesn't even seem to be
+# doing (the equivalent of) that.
 
-    # HACK: copied verbatim from test_05
+# def test_cpu():
+#     cpu = run(project_05.CPU.constr())
 
-    cpu.instruction = 0b0011000000111001  # @12345
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 12345 and cpu.pc == 1 # and DRegister == 0
+#     # HACK: copied verbatim from test_05
 
-    cpu.instruction = 0b1110110000010000  # D=A
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 12345 and cpu.pc == 2 # and DRegister == 12345
+#     cpu.instruction = 0b0011000000111001  # @12345
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 12345 and cpu.pc == 1 # and DRegister == 0
 
-    cpu.instruction = 0b0101101110100000  # @23456
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 23456 and cpu.pc == 3 # and DRegister == 12345
+#     cpu.instruction = 0b1110110000010000  # D=A
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 12345 and cpu.pc == 2 # and DRegister == 12345
 
-    cpu.instruction = 0b1110000111010000  # D=A-D
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 23456 and cpu.pc == 4 # and DRegister == 11111
+#     cpu.instruction = 0b0101101110100000  # @23456
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 23456 and cpu.pc == 3 # and DRegister == 12345
 
-    cpu.instruction = 0b0000001111101000  # @1000
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 5 # and DRegister == 11111
+#     cpu.instruction = 0b1110000111010000  # D=A-D
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 23456 and cpu.pc == 4 # and DRegister == 11111
 
-    cpu.instruction = 0b1110001100001000  # M=D
-    cpu.tick(); cpu.tock()
-    assert cpu.outM == 11111 and cpu.writeM == 1 and cpu.addressM == 1000 and cpu.pc == 6 # and DRegister == 11111
+#     cpu.instruction = 0b0000001111101000  # @1000
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 5 # and DRegister == 11111
 
-    cpu.instruction = 0b0000001111101001  # @1001
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1001 and cpu.pc == 7 # and DRegister == 11111
+#     cpu.instruction = 0b1110001100001000  # M=D
+#     cpu.tick(); cpu.tock()
+#     assert cpu.outM == 11111 and cpu.writeM == 1 and cpu.addressM == 1000 and cpu.pc == 6 # and DRegister == 11111
 
-    # Note confusing timing here: outM has the value to be written to memory when the clock falls. Afterward,
-    # outM has a nonsense value.
-    # TODO: always assert outM and writeM before tick/tock?
-    cpu.instruction = 0b1110001110011000  # MD=D-1
-    assert cpu.outM == 11110 and cpu.writeM == 1 and cpu.addressM == 1001 and cpu.pc == 7 # and DRegister == 11111
-    cpu.tick(); cpu.tock()
-    assert cpu.outM == 11109 and cpu.writeM == 1 and cpu.addressM == 1001 and cpu.pc == 8 # and DRegister == 11110
+#     cpu.instruction = 0b0000001111101001  # @1001
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1001 and cpu.pc == 7 # and DRegister == 11111
 
-    cpu.instruction = 0b0000001111101000  # @1000
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 9 # and DRegister == 11110
+#     # Note confusing timing here: outM has the value to be written to memory when the clock falls. Afterward,
+#     # outM has a nonsense value.
+#     # TODO: always assert outM and writeM before tick/tock?
+#     cpu.instruction = 0b1110001110011000  # MD=D-1
+#     assert cpu.outM == 11110 and cpu.writeM == 1 and cpu.addressM == 1001 and cpu.pc == 7 # and DRegister == 11111
+#     cpu.tick(); cpu.tock()
+#     assert cpu.outM == 11109 and cpu.writeM == 1 and cpu.addressM == 1001 and cpu.pc == 8 # and DRegister == 11110
 
-    cpu.instruction = 0b1111010011010000  # D=D-M
-    cpu.inM = 11111
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 10 # and DRegister == -1
+#     cpu.instruction = 0b0000001111101000  # @1000
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 9 # and DRegister == 11110
 
-    cpu.instruction = 0b0000000000001110  # @14
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 14 and cpu.pc == 11 # and DRegister == -1
+#     cpu.instruction = 0b1111010011010000  # D=D-M
+#     cpu.inM = 11111
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 10 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100000100  # D;jlt
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 14 and cpu.pc == 14 # and DRegister == -1
+#     cpu.instruction = 0b0000000000001110  # @14
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 14 and cpu.pc == 11 # and DRegister == -1
 
-    cpu.instruction = 0b0000001111100111  # @999
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 999 and cpu.pc == 15 # and DRegister == -1
+#     cpu.instruction = 0b1110001100000100  # D;jlt
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 14 and cpu.pc == 14 # and DRegister == -1
 
-    cpu.instruction = 0b1110110111100000  # A=A+1
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 16 # and DRegister == -1
+#     cpu.instruction = 0b0000001111100111  # @999
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 999 and cpu.pc == 15 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100001000  # M=D
-    cpu.tick(); cpu.tock()
-    assert cpu.outM == -1 and cpu.writeM == 1 and cpu.addressM == 1000 and cpu.pc == 17 # and DRegister == -1
+#     cpu.instruction = 0b1110110111100000  # A=A+1
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 16 # and DRegister == -1
 
-    cpu.instruction = 0b0000000000010101  # @21
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 21 and cpu.pc == 18 # and DRegister == -1
+#     cpu.instruction = 0b1110001100001000  # M=D
+#     cpu.tick(); cpu.tock()
+#     assert cpu.outM == -1 and cpu.writeM == 1 and cpu.addressM == 1000 and cpu.pc == 17 # and DRegister == -1
 
-    cpu.instruction = 0b1110011111000010  # D+1;jeq
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 21 and cpu.pc == 21 # and DRegister == -1
+#     cpu.instruction = 0b0000000000010101  # @21
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 21 and cpu.pc == 18 # and DRegister == -1
 
-    cpu.instruction = 0b0000000000000010  # @2
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 2 and cpu.pc == 22 # and DRegister == -1
+#     cpu.instruction = 0b1110011111000010  # D+1;jeq
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 21 and cpu.pc == 21 # and DRegister == -1
 
-    cpu.instruction = 0b1110000010010000  # D=D+A
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 2 and cpu.pc == 23 # and DRegister == 1
+#     cpu.instruction = 0b0000000000000010  # @2
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 2 and cpu.pc == 22 # and DRegister == -1
 
-    cpu.instruction = 0b0000001111101000  # @1000
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 24 # and DRegister == -1
+#     cpu.instruction = 0b1110000010010000  # D=D+A
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 2 and cpu.pc == 23 # and DRegister == 1
 
-    cpu.instruction = 0b1110111010010000  # D=-1
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 25 # and DRegister == -1
+#     cpu.instruction = 0b0000001111101000  # @1000
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 24 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100000001  # D;JGT
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 26 # and DRegister == -1
+#     cpu.instruction = 0b1110111010010000  # D=-1
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 25 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100000010  # D;JEQ
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 27 # and DRegister == -1
+#     cpu.instruction = 0b1110001100000001  # D;JGT
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 26 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100000011  # D;JGE
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 28 # and DRegister == -1
+#     cpu.instruction = 0b1110001100000010  # D;JEQ
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 27 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100000100  # D;JLT
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
+#     cpu.instruction = 0b1110001100000011  # D;JGE
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 28 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100000101  # D;JNE
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
+#     cpu.instruction = 0b1110001100000100  # D;JLT
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100000110  # D;JLE
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
+#     cpu.instruction = 0b1110001100000101  # D;JNE
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100000111  # D;JMP
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
+#     cpu.instruction = 0b1110001100000110  # D;JLE
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
-    cpu.instruction = 0b1110101010010000  # D=0
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 0
+#     cpu.instruction = 0b1110001100000111  # D;JMP
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == -1
 
-    cpu.instruction = 0b1110001100000001  # D;JGT
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1002 # and DRegister == 0
+#     cpu.instruction = 0b1110101010010000  # D=0
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 0
 
-    cpu.instruction = 0b1110001100000010  # D;JEQ
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
+#     cpu.instruction = 0b1110001100000001  # D;JGT
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1002 # and DRegister == 0
 
-    cpu.instruction = 0b1110001100000011  # D;JGE
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
+#     cpu.instruction = 0b1110001100000010  # D;JEQ
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
-    cpu.instruction = 0b1110001100000100  # D;JLT
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 0
+#     cpu.instruction = 0b1110001100000011  # D;JGE
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
-    cpu.instruction = 0b1110001100000101  # D;JNE
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1002 # and DRegister == 0
+#     cpu.instruction = 0b1110001100000100  # D;JLT
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 0
 
-    cpu.instruction = 0b1110001100000110  # D;JLE
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
+#     cpu.instruction = 0b1110001100000101  # D;JNE
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1002 # and DRegister == 0
 
-    cpu.instruction = 0b1110001100000111  # D;JMP
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
+#     cpu.instruction = 0b1110001100000110  # D;JLE
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
-    cpu.instruction = 0b1110111111010000  # D=1
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
+#     cpu.instruction = 0b1110001100000111  # D;JMP
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 0
 
-    cpu.instruction = 0b1110001100000001  # D;JGT
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
+#     cpu.instruction = 0b1110111111010000  # D=1
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
-    cpu.instruction = 0b1110001100000010  # D;JEQ
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
+#     cpu.instruction = 0b1110001100000001  # D;JGT
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
-    cpu.instruction = 0b1110001100000011  # D;JGE
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
+#     cpu.instruction = 0b1110001100000010  # D;JEQ
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
-    cpu.instruction = 0b1110001100000100  # D;JLT
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
+#     cpu.instruction = 0b1110001100000011  # D;JGE
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
-    cpu.instruction = 0b1110001100000101  # D;JNE
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
+#     cpu.instruction = 0b1110001100000100  # D;JLT
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
-    cpu.instruction = 0b1110001100000110  # D;JLE
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
+#     cpu.instruction = 0b1110001100000101  # D;JNE
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
-    cpu.instruction = 0b1110001100000111  # D;JMP
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
+#     cpu.instruction = 0b1110001100000110  # D;JLE
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1001 # and DRegister == 1
 
-    cpu.reset = 1
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 0 # and DRegister == 1
+#     cpu.instruction = 0b1110001100000111  # D;JMP
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 1000 # and DRegister == 1
 
-    cpu.instruction = 0b0111111111111111  # @32767
-    cpu.reset = 0
-    cpu.tick(); cpu.tock()
-    assert cpu.writeM == 0 and cpu.addressM == 32767 and cpu.pc == 1 # and DRegister == 1
+#     cpu.reset = 1
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 1000 and cpu.pc == 0 # and DRegister == 1
 
-
-def test_computer_add():
-    computer = run(project_05.Computer.constr())
-
-    # First run (at the beginning PC=0)
-    computer.run_program(test_05.ADD_PROGRAM)
-
-    assert computer.peek(1) == 5
+#     cpu.instruction = 0b0111111111111111  # @32767
+#     cpu.reset = 0
+#     cpu.tick(); cpu.tock()
+#     assert cpu.writeM == 0 and cpu.addressM == 32767 and cpu.pc == 1 # and DRegister == 1
 
 
-    # Reset the PC
-    computer.reset = 1
-    computer.ticktock()
-    assert computer.pc == 0
+# def test_computer_add():
+#     computer = run(project_05.Computer.constr())
 
-    # Second run, to check that the PC was reset correctly.
-    computer.poke(0, 12345)
-    computer.reset = 0
-    while computer.pc < len(test_05.ADD_PROGRAM):
-        computer.ticktock()
+#     # First run (at the beginning PC=0)
+#     computer.run_program(test_05.ADD_PROGRAM)
 
-    assert computer.peek(1) == 5
+#     assert computer.peek(1) == 5
+
+
+#     # Reset the PC
+#     computer.reset = 1
+#     computer.ticktock()
+#     assert computer.pc == 0
+
+#     # Second run, to check that the PC was reset correctly.
+#     computer.poke(0, 12345)
+#     computer.reset = 0
+#     while computer.pc < len(test_05.ADD_PROGRAM):
+#         computer.ticktock()
+
+#     assert computer.peek(1) == 5
 
 
 def test_computer_max():

--- a/nand/vector.py
+++ b/nand/vector.py
@@ -237,17 +237,16 @@ class RAMOps(VectorOps):
         """Note: not using `out`."""
         assert len(in_) == 16 and len(load) == 1 and len(address) == self.comp.address_bits
         def update(traces):
-            address_val = get_multiple_traces(address, traces)
-
             # Store the new value, if `load` is high:
             load_val = tst_trace(load[0], traces)
             if load_val:
                 # Tricky: sign extension was never needed here until eight.py, and it will
                 # hurt performance slightly.
                 in_val = extend_sign(get_multiple_traces(in_, traces))
-                self.set(address_val, in_val)
+                self.set(self.latched_address, in_val)
 
-            # Store the address, regardless:
+            # Store the address for next cycle:
+            address_val = get_multiple_traces(address, traces)
             self.latched_address = address_val
 
             return traces

--- a/project_05.py
+++ b/project_05.py
@@ -33,6 +33,7 @@ def MemorySystem(inputs, outputs):
 
     # SOLVERS: replace this with one or more Nands and/or components defined above
     # Hint: you'll need a RAM(14), a RAM(13), an Input, and an Output.
+    # DO NOT use the RAMxx you built in project_03, it will be too slow to simulate.
     n1 = solved_05.MemorySystem(in_=in_, load=load, address=address)
 
     outputs.out = n1.out

--- a/test_03.py
+++ b/test_03.py
@@ -206,6 +206,7 @@ def ram_test(ram, size):
     ram.load = 0
     for i in addrs:
         ram.address = i
+        ram.tick(); ram.tock()  # Note: one-cycle latency is now expected for the "real" RAM
         assert ram.out == i
 
 

--- a/test_03.py
+++ b/test_03.py
@@ -197,8 +197,9 @@ def ram_test(ram, size):
 
     ram.load = 1
     for i in addrs:
-        ram.in_ = i
         ram.address = i
+        ram.tick(); ram.tock()  # Note: one-cycle latency is now expected for writes also
+        ram.in_ = i
         ram.tick(); ram.tock()
         assert ram.out == i
 

--- a/test_05.py
+++ b/test_05.py
@@ -22,8 +22,10 @@ def test_memory_system():
 
     # Did not also write to upper RAM or Screen
     mem.address = 0x2000
+    mem.tick(); mem.tock()
     assert mem.out == 0
     mem.address = 0x4000
+    mem.tick(); mem.tock()
     assert mem.out == 0
 
     # Set RAM[2000] = 2222
@@ -41,26 +43,28 @@ def test_memory_system():
 
     # Did not also write to lower RAM or Screen
     mem.address = 0
+    mem.tick(); mem.tock()
     assert mem.out == -1
     mem.address = 0x4000
+    mem.tick(); mem.tock()
     assert mem.out == 0
 
     # Low order address bits connected
     # (note: not actually testing anything in this system?)
-    mem.address = 0x0001; assert mem.out == 0
-    mem.address = 0x0002; assert mem.out == 0
-    mem.address = 0x0004; assert mem.out == 0
-    mem.address = 0x0008; assert mem.out == 0
-    mem.address = 0x0010; assert mem.out == 0
-    mem.address = 0x0020; assert mem.out == 0
-    mem.address = 0x0040; assert mem.out == 0
-    mem.address = 0x0080; assert mem.out == 0
-    mem.address = 0x0100; assert mem.out == 0
-    mem.address = 0x0200; assert mem.out == 0
-    mem.address = 0x0400; assert mem.out == 0
-    mem.address = 0x0800; assert mem.out == 0
-    mem.address = 0x1000; assert mem.out == 0
-    mem.address = 0x2000; assert mem.out == 2222
+    mem.address = 0x0001; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0002; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0004; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0008; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0010; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0020; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0040; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0080; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0100; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0200; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0400; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x0800; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x1000; mem.tick(); mem.tock(); assert mem.out == 0
+    mem.address = 0x2000; mem.tick(); mem.tock(); assert mem.out == 2222
 
     # RAM[0x1234] = 1234
     mem.address = 0x1234
@@ -70,9 +74,12 @@ def test_memory_system():
     assert mem.out == 1234
 
     # Did not also write to upper RAM or Screen
+    mem.load = 0
     mem.address = 0x2234
+    mem.tick(); mem.tock()
     assert mem.out == 0
     mem.address = 0x6234
+    mem.tick(); mem.tock()
     assert mem.out == 0
 
     # RAM[0x2345] = 2345
@@ -83,9 +90,12 @@ def test_memory_system():
     assert mem.out == 2345
 
     # Did not also write to lower RAM or Screen
+    mem.load = 0
     mem.address = 0x0345
+    mem.tick(); mem.tock()
     assert mem.out == 0
     mem.address = 0x4345
+    mem.tick(); mem.tock()
     assert mem.out == 0
 
 

--- a/test_05.py
+++ b/test_05.py
@@ -29,9 +29,11 @@ def test_memory_system():
     assert mem.out == 0
 
     # Set RAM[2000] = 2222
-    mem.in_ = 2222
-    mem.load = 1
+    # Tricky: this now takes a two-cycle sequence
     mem.address = 0x2000
+    mem.tick(); mem.tock()
+    mem.load = 1
+    mem.in_ = 2222
     mem.tick(); mem.tock()
     assert mem.out == 2222
 
@@ -67,7 +69,9 @@ def test_memory_system():
     mem.address = 0x2000; mem.tick(); mem.tock(); assert mem.out == 2222
 
     # RAM[0x1234] = 1234
+    # Tricky: this now takes a two-cycle sequence
     mem.address = 0x1234
+    mem.tick(); mem.tock()
     mem.in_ = 1234
     mem.load = 1
     mem.tick(); mem.tock()
@@ -83,7 +87,9 @@ def test_memory_system():
     assert mem.out == 0
 
     # RAM[0x2345] = 2345
+    # Tricky: this now takes a two-cycle sequence
     mem.address = 0x2345
+    mem.tick(); mem.tock()
     mem.in_ = 2345
     mem.load = 1
     mem.tick(); mem.tock()
@@ -110,15 +116,19 @@ def test_memory_system():
 
     ### Screen test
 
+    # Tricky: this now takes a two-cycle sequence
+    mem.address = 0x4fcf
+    mem.tick(); mem.tock()
     mem.load = 1
     mem.in_ = -1
-    mem.address = 0x4fcf
     mem.tick(); mem.tock()
     assert mem.out == -1
 
     mem.address = 0x504f
-    mem.tick(); mem.tock()
+    mem.tick(); mem.tock()  # latch the address
+    mem.tick(); mem.tock()  # store the value
     assert mem.out == -1
+
 
 def a_contents(cpu):
     """Inspect the contents of the A register, by applying a bit pattern that forces it onto the memory input."""

--- a/test_optimal_05.py
+++ b/test_optimal_05.py
@@ -4,25 +4,67 @@
 in using the minimum number of gates and/or making the (theoretically) fastest circuits.
 """
 
-from nand import gate_count
-from project_05 import *
+import pytest
+
+from nand import gate_count, run
+from nand.syntax import chip
+import project_05
 
 def test_memory_system():
-    assert gate_count(MemorySystem) == {
+    assert gate_count(project_05.MemorySystem) == {
         'nands': 163,  # ?
         'rams': 2,
         'inputs': 1,
         'outputs': 1,
     }
 
+@pytest.mark.parametrize("simulator", ["vector", "codegen"])
+def test_memory_latency(simulator, memory=project_05.MemorySystem):
+    """Verify timing constraints specified by the RAM component (and provided by the native
+    implementations).
+    """
+
+    chip = run(memory, simulator=simulator)
+
+    # Write a series of values to the first few addresses:
+    # Note: all three inputs provided in the same cycle; throughput is 1 write/cycle.
+    for i in range(10):
+        chip.load = 1
+        chip.address = i
+        chip.in_ = i
+
+        # The previous cycle's value is read:
+        assert chip.out == (i-1 if i > 0 else 0)
+
+        chip.ticktock()
+
+    chip.load = 0
+    chip.address = 0
+    chip.ticktock()
+
+    # Read each value, and verify timing:
+    # Note: throughput is 1 read/cycle.
+    for i in range(1, 10):
+        # First, check the output when the address has not been updated since the previous cycle:
+        assert chip.out == i-1
+
+        # Now supply the address to be read on the _next_ cycle:
+        chip.address = i
+
+        # Even after applying the new address, the output still reflects the latched address:
+        assert chip.out == i-1
+
+        chip.ticktock()
+
+
 def test_cpu():
-    assert gate_count(CPU) == {
+    assert gate_count(project_05.CPU) == {
         'nands': 1099,  # ?
         'dffs': 48,  # 3 registers
     }
 
 def test_computer():
-    assert gate_count(Computer) == {
+    assert gate_count(project_05.Computer) == {
         'nands': 1262,  # ?
         'dffs': 48,  # 3 registers
         'roms': 1,

--- a/test_optimal_05.py
+++ b/test_optimal_05.py
@@ -27,32 +27,37 @@ def test_memory_latency(simulator, memory=project_05.MemorySystem):
     chip = run(memory, simulator=simulator)
 
     # Write a series of values to the first few addresses:
-    # Note: all three inputs provided in the same cycle; throughput is 1 write/cycle.
-    for i in range(10):
-        chip.load = 1
-        chip.address = i
-        chip.in_ = i
 
-        # The previous cycle's value is read:
-        assert chip.out == (i-1 if i > 0 else 0)
-
-        chip.ticktock()
-
-    chip.load = 0
+    # Set up the address for the first write:
     chip.address = 0
     chip.ticktock()
 
+    chip.load = 1
+    for i in range(0, 10):
+        # Note: i is the address that we're writing now
+
+        assert chip.out == 0   # always 0; hasn't been written yet
+
+        chip.in_ = i        # value for _this_ write
+        chip.address = i+1  # address for the _next_ write
+
+        chip.ticktock()
+
+    chip.address = 0
+    chip.ticktock()
+
+    chip.load = 0
     # Read each value, and verify timing:
     # Note: throughput is 1 read/cycle.
-    for i in range(1, 10):
+    for i in range(10):
         # First, check the output when the address has not been updated since the previous cycle:
-        assert chip.out == i-1
+        assert chip.out == i
 
         # Now supply the address to be read on the _next_ cycle:
-        chip.address = i
+        chip.address = i+1
 
         # Even after applying the new address, the output still reflects the latched address:
-        assert chip.out == i-1
+        assert chip.out == i
 
         chip.ticktock()
 

--- a/test_optimal_05.py
+++ b/test_optimal_05.py
@@ -64,13 +64,13 @@ def test_memory_latency(simulator, memory=project_05.MemorySystem):
 
 def test_cpu():
     assert gate_count(project_05.CPU) == {
-        'nands': 1099,  # ?
+        'nands': 1151,  # ?
         'dffs': 48,  # 3 registers
     }
 
 def test_computer():
     assert gate_count(project_05.Computer) == {
-        'nands': 1262,  # ?
+        'nands': 1314,  # ?
         'dffs': 48,  # 3 registers
         'roms': 1,
         'rams': 2,


### PR DESCRIPTION
Fixes #34.

***NB***: Turns out the blast radius is pretty large. Making the system more "realistic" by adding this complexity is interesting when you want to experiment with alternative designs (see the `risc` branch), but seems to be at odds with the goal of keeping the course approachable. *Maybe don't merge this; instead, rip out all the "advanced" stuff to a separate repo, possibly sharing the basic simulation infrastructure.*

Not only reads but also writes had to be modified to use the address which was applied to the memory on the _previous_ cycle, so that the standard CPUs single-cycle read/write can still work (e.g. `M=M-1`).

Effectively you have to think about "pipelining" the address even in the standard CPU, which is more than most hypothetical solvers will probably want to deal with.

It also means some modification to the tests which were imported directly from the original course materials:

The tests for user-constructed "RAM"s now tolerate this sequence, but don't actually require it. 

The tests for CPUs unfortunately now require the new behavior, and they're significantly harder to follow as a result.

This also makes it painfully clear how badly the `codegen` simulator is in need of refactoring.